### PR TITLE
Format spec definition list

### DIFF
--- a/_templates/README.md
+++ b/_templates/README.md
@@ -5,13 +5,13 @@
 In the OpenAI video Introducing Specs
 , a spec (short for specification) is a structured document that clearly defines:
 
-the goal of a task,
+- the goal of a task
 
-the steps required,
+- the steps required
 
-the expected inputs/outputs, and
+- the expected inputs/outputs
 
-the evaluation criteria.
+- the evaluation criteria.
 
 It acts as a contract between humans and AI systems, ensuring consistency, reproducibility, and clarity in how work is done.
 


### PR DESCRIPTION
## Summary
- convert the list of spec attributes in `_templates/README.md` to a proper Markdown bullet list so it renders correctly

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d59913140c83338633425f6c9f979a