### PR TITLE
Normalize bullets in prompts explainer

### DIFF
--- a/_templates/README.md
+++ b/_templates/README.md
@@ -42,6 +42,6 @@ In research: Specs define methodology (e.g., data sources, models, reproducibili
 In policy/consulting: Specs provide consistent evaluation frameworks (e.g., for assessing monetary policy). Prompts generate scenario narratives and what-if analyses.
 
 How specs & prompts complement each other (quick explainer to include in class)
-•	Specs = blueprint/contract (objective, scope, inputs, steps, outputs, evaluation).
-•	Prompts = tactical instructions you run at each step.
-•	Together they enforce clarity, consistency, and reproducibility — exactly what employers expect.
+- Specs = blueprint/contract (objective, scope, inputs, steps, outputs, evaluation).
+- Prompts = tactical instructions you run at each step.
+- Together they enforce clarity, consistency, and reproducibility — exactly what employers expect.


### PR DESCRIPTION
## Summary
- convert the "How specs & prompts complement each other" section to use standard markdown list markers
- ensure the bullet text reads naturally without extra spacing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5991559bc8333af57cd1680521e75