### PR TITLE
Fix formatting in README template

### DIFF
--- a/_templates/README-broken.md
+++ b/_templates/README-broken.md
@@ -1,47 +1,38 @@
-:
+## What is a “spec”?
 
-🔹 What is a “spec”?
+In the OpenAI video Introducing Specs, a spec (short for specification) is a structured document that clearly defines:
 
-In the OpenAI video Introducing Specs
-, a spec (short for specification) is a structured document that clearly defines:
-
-the goal of a task,
-
-the steps required,
-
-the expected inputs/outputs, and
-
-the evaluation criteria.
+- the goal of a task,
+- the steps required,
+- the expected inputs/outputs, and
+- the evaluation criteria.
 
 It acts as a contract between humans and AI systems, ensuring consistency, reproducibility, and clarity in how work is done.
 
-🔹 Specs vs. Prompts
+## Specs vs. Prompts
 
-Prompts: Instructions given to an AI in natural language. They are flexible, conversational, and immediate. Example: “Explain Interest Rate Parity with an example.”
+Prompts are instructions given to an AI in natural language. They are flexible, conversational, and immediate. Example: “Explain Interest Rate Parity with an example.”
 
-Specs: Formalized blueprints that outline how to approach a problem systematically. They provide context, requirements, and evaluation rules.
+Specs are formalized blueprints that outline how to approach a problem systematically. They provide context, requirements, and evaluation rules.
 
-How they complement each other:
+### How they complement each other
 
-A spec defines the scope and structure of a task.
+1. A spec defines the scope and structure of a task.
+2. A prompt executes a part of that task inside the spec.
 
-A prompt executes a part of that task inside the spec.
+### In practice
 
-In practice:
+- The spec ensures that multiple people (or agents) would approach the problem the same way.
+- The prompts are the tactical instructions used at each stage.
 
-The spec ensures that multiple people (or agents) would approach the problem the same way.
+## Using Specs + Prompts in Economics
 
-The prompts are the tactical instructions used at each stage.
+- **In teaching:** Specs define structured student projects (e.g., analyzing tariffs, calculating FX hedges). Prompts help students generate analysis, visuals, or summaries.
+- **In research:** Specs define methodology (e.g., data sources, models, reproducibility requirements). Prompts handle execution (e.g., regression code, lit review summaries).
+- **In policy/consulting:** Specs provide consistent evaluation frameworks (e.g., for assessing monetary policy). Prompts generate scenario narratives and what-if analyses.
 
-🔹 Using Specs + Prompts in Economics
+### How specs & prompts complement each other (quick explainer to include in class)
 
-In teaching: Specs define structured student projects (e.g., analyzing tariffs, calculating FX hedges). Prompts help students generate analysis, visuals, or summaries.
-
-In research: Specs define methodology (e.g., data sources, models, reproducibility requirements). Prompts handle execution (e.g., regression code, lit review summaries).
-
-In policy/consulting: Specs provide consistent evaluation frameworks (e.g., for assessing monetary policy). Prompts generate scenario narratives and what-if analyses.
-
-How specs & prompts complement each other (quick explainer to include in class)
-•	Specs = blueprint/contract (objective, scope, inputs, steps, outputs, evaluation).
-•	Prompts = tactical instructions you run at each step.
-•	Together they enforce clarity, consistency, and reproducibility — exactly what employers expect.
+- Specs = blueprint/contract (objective, scope, inputs, steps, outputs, evaluation).
+- Prompts = tactical instructions you run at each step.
+- Together they enforce clarity, consistency, and reproducibility — exactly what employers expect.


### PR DESCRIPTION
## Summary
- convert emoji headings in `_templates/README-broken.md` into standard Markdown headers
- reflow broken paragraphs and convert improvised bullets into proper Markdown lists

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5ec68752c83338da4d4290b9bfeee