### PR TITLE
Case 1 briefs converted to the stage-brief template

### DIFF
--- a/courses/Micro-And-Macro-Economics/projects/in-progress/perfect-competition-marginal-costs/stage1-repo-and-brief.md
+++ b/courses/Micro-And-Macro-Economics/projects/in-progress/perfect-competition-marginal-costs/stage1-repo-and-brief.md
@@ -1,201 +1,185 @@
+---
+template: stage-brief
+project: perfect-competition-marginal-costs
+stage: 1
+title: "Repo + Brief"
+capability: marginal-analysis
+deliverables:
+  - path: "(repository) firstname-lastname"
+    format: repo
+    ai_boundary: ai-first-verified
+  - path: docs/briefs/perfect-competition-brief.md
+    format: markdown
+    ai_boundary: human-first
+prerequisites: []
+points: 3
+estimated_time: "60-80 min"
+---
+
 # Case 1 · Stage 1 — Repo + Brief
 
-**Case weight:** 10% of course grade — this stage: 3 of 20 pts
-**Format:** Upload-only — no presentation component
-**Deliverable:** Public GitHub repository URL (repo contains the portfolio skeleton + `docs/briefs/perfect-competition-brief.md`) submitted via Lamaku
-**Due:** end of Week 1 — exact dates on the course calendar (Case 1 spans Weeks 1–2, Aug 24–Sep 4)
+**Deliverable:** the portfolio repository, and `docs/briefs/perfect-competition-brief.md` inside it
+**Submission:** committed and pushed to your public repository; graded by inspection
+**Estimated time:** 60–80 minutes
 
 ---
 
-## Overview
+## 1. Purpose
 
-You are a farmer on a 1.5-acre market garden, and in a few weeks you have to commit the whole season to a planting plan you cannot undo. Over the next two weeks you will work out what that plan should be — and you will document it the way a consultant documents work for a client who has to live with the answer, because that client is your own operation. Everything you produce lands in one place: a **public GitHub portfolio repo** that you stand up in this stage and never rebuild.
+This stage produces two things: the public portfolio repository that every engagement lands in, and
+a one-page engagement brief stating the farm's problem in your own words and ending in a hypothesis
+you can be shown wrong about. Neither is analysis. Both are the conditions that make the analysis
+worth anything — and the brief has to exist before the model does, because Stage 3 compares what you
+predicted against what the model found, and that comparison cannot be reconstructed afterwards.
 
-Two things happen here, and both are deliberately small: the repo goes live, and you write a one-page **engagement brief** stating the problem in your own words — including a hypothesis about the answer *before you have run anything*.
+## 2. Prerequisites
 
-The repo is not busywork, and it is not a course folder. It is structured the way a working analyst's practice is structured — **capabilities you can do**, and **engagements that prove you did them** — so it keeps working after this class, after this degree, and into a job. Three engagements this semester land in it; so does everything you do in later courses.
+None. This is the entry point for the engagement and for the repository.
 
-The brief matters for a different reason: a hypothesis written *before* Solver runs is falsifiable. One written after is a summary. Stage 3 asks you to compare what you expected against what the model found — that comparison only exists if you commit to a guess now.
+Read before starting:
 
-We walk through repo setup at the in-class kickoff; DLEMBA students get a screencast kickoff instead — same steps, same deliverables.
+- [The portfolio repo standard](https://adamwstauffer.github.io/ai-lms/portfolio-repo.html) — the structure, the four starter files, and a prompt that builds the skeleton
+- [AI conventions](https://adamwstauffer.github.io/ai-lms/ai-conventions.html) — what goes in `AGENTS.md`, and what must never be committed
+- [Git mechanics](https://adamwstauffer.github.io/ai-lms/onboarding.html#git-mechanics) — local versus remote, add → commit → push, `.gitignore`, and how work is submitted
+- [Deliverable templates](https://adamwstauffer.github.io/ai-lms/deliverable-templates.html) — the shape of a brief
+- The [case README](README.md) — scenario, assumptions table, constraints
 
-> **Never used GitHub before?** This doc is the on-ramp — it's enough. For deeper coverage of anything below (first commit, larger files, troubleshooting), the full reference is [`docs/guides/github-mba-guide.md`](../../../../../docs/guides/github-mba-guide.md) in the course repo, and the [Kumu Start Here page](https://adamwstauffer.github.io/ai-lms/onboarding.html#git-mechanics) covers the add → commit → push loop with screenshots. Keep one open in another tab; don't read either cover-to-cover.
+## 3. Deliverables
 
----
+| Artifact | Path | Format |
+|---|---|---|
+| Public portfolio repository, named for you | `github.com/{you}/firstname-lastname` | repository |
+| Bio and engagement index | `README.md` | markdown |
+| AI conventions, and the pointer to them | `AGENTS.md`, `CLAUDE.md` | markdown |
+| Resume and prompt log, started | `RESUME.md`, `prompt-log.md` | markdown |
+| Exclusion rules | `.gitignore` | text |
+| The engagement brief | `docs/briefs/perfect-competition-brief.md` | markdown |
 
-## The four steps
+## 4. Background
 
-| Step | What you do | Time |
-|------|-------------|------|
-| **1** | Create a GitHub account | 5 min |
-| **2** | Install GitHub Desktop | 10 min |
-| **3** | Create your public repo + portfolio skeleton | 20 min |
-| **4** | Write `docs/briefs/perfect-competition-brief.md` and push it | 30–45 min |
+A prediction written *before* the model runs is falsifiable. The same sentence written afterwards is
+a summary of the output, and it teaches you nothing, because you can no longer distinguish "I
+understood the economics" from "I read the answer cell."
 
----
+This is not a classroom convention. It is why an analyst writes an engagement brief before opening
+the data, and why "we always thought so" is the least trustworthy sentence in business. A wrong
+hypothesis, precisely reasoned, is worth as much as a correct one and considerably more than a lucky
+one.
 
-## Step 1 — Create a GitHub account
+What makes a hypothesis genuine is that some outcome would refute it. *"I expect roughly 15 tomato
+beds, 20 carrot, 25 mesclun, because tomatoes earn about four times what carrots do per bed and I
+doubt the labor penalty closes that gap"* names quantities and a mechanism, and the model can
+contradict it. *"I expect a balanced mix because diversification reduces risk"* would survive any
+result, which is what disqualifies it.
 
-1. Go to [github.com](https://github.com) and click **Sign up**.
-2. **Use your `@hawaii.edu` email.** It makes you eligible for [GitHub Education](https://education.github.com) — free GitHub Pro, free Copilot, instant approval in most cases.
-3. **Choose a professional username.** This is effectively a second business card — reviewers, managers, and admissions committees will see it. Good: `firstname-lastname`, `flastname`. Avoid gamer tags, joke names, anything you wouldn't put on a resume.
-4. Verify your email, and (recommended) upload a profile photo so your instructor can recognize you on the platform.
+## 5. Procedure
 
-## Step 2 — Install GitHub Desktop
+1. **Create the GitHub account.** Use your `@hawaii.edu` address — it qualifies for
+   [GitHub Education](https://education.github.com). Choose a professional username; it appears
+   beside every piece of work you publish.
+   *Confirm:* you can sign in, and the email is verified.
 
-We use **GitHub Desktop** — a free visual app that handles clone, commit, and push through buttons. No terminal, no command line, ever.
+2. **Install GitHub Desktop**, or use the command line if you already prefer it. The deliverable is
+   identical either way.
+   *Confirm:* the app is signed in, and your Git config carries your real name and `.edu` address —
+   both are stamped on every commit.
 
-1. Download from [desktop.github.com](https://desktop.github.com) and run the installer (Windows auto-installs Git in the background; Mac: drag to Applications).
-2. On first launch, **sign in** with the account from Step 1.
-3. Confirm your **Git config** — real name, `@hawaii.edu` email. These get stamped on every commit.
+3. **Create the repository.** Name it `firstname-lastname`, set visibility to **public**, and
+   initialize it with a README so it can be cloned.
+   *Confirm:* the repository URL opens in a private browser window without a login prompt.
 
-If you're already comfortable with the Git CLI, use it — the deliverable is identical either way.
+4. **Clone it, then build the skeleton** to the structure in the portfolio repo standard. Creating
+   directories is mechanical work — use the starter prompt on that page and check the result rather
+   than typing it out.
+   *Confirm:* every directory holds at least one file, or Git will not track it.
 
-## Step 3 — Create your repo + portfolio skeleton
+5. **Write the four root files.** Replace the generated `README.md` with three to six sentences on
+   who you are, followed by an engagement index. Add `RESUME.md`, `AGENTS.md` (start from the
+   baseline on the AI conventions page and edit until it describes you), and the one-line
+   `CLAUDE.md` pointing at it.
+   *Confirm:* nothing in these files is placeholder text you would not want read.
 
-### 3a. Create the repo on GitHub
+6. **Add `.gitignore`** before any workbook is committed, using the starter block in
+   [Git mechanics](https://adamwstauffer.github.io/ai-lms/onboarding.html#gitignore).
+   *Confirm:* `~$`-prefixed files never appear in your Changes panel.
 
-1. On [github.com](https://github.com): **+** (top-right) → **New repository**.
-2. **Name it after *you*, not this course:** `firstname-lastname` (or `firstname-lastname-portfolio` if taken). This repo outlives BUS 620 — all three engagements, later courses, and work you do after graduation land here. Name it for the person.
-3. **Visibility: Public.** Non-negotiable — a portfolio nobody can see isn't one.
-4. Check **Add a README file** (an empty repo can't be cloned).
-5. Click **Create repository**.
+7. **Add your instructor as a collaborator** — repository **Settings → Collaborators → Add people**,
+   then `adamwstauffer`. Collaborator access is what allows a review branch or a pull request against
+   your work instead of an emailed paragraph.
+   *Confirm:* the invitation shows as pending. You do not need to wait for it.
 
-### 3b. Clone it locally
+8. **Write the brief** at `docs/briefs/perfect-competition-brief.md`, using the structure on the
+   deliverable-templates page. Read the [case README](README.md) first, then — **before opening the
+   workbook or Solver** — write half a page to a page covering two things:
+   - **The problem in your own words.** What the farm is deciding, what is fixed, what is chosen,
+     what limits the choice. If you cannot state it without re-reading the case, you do not have it
+     yet, and that is useful information about where the next hour goes.
+   - **Your hypothesis.** *"I expect the optimal mix to be X because Y."* Real quantities — beds of
+     tomatoes, carrots, mesclun — and real reasoning: prices per bed, labor intensity, the
+     diminishing-returns percentages, the caps. Name the mechanism you think decides it.
 
-In GitHub Desktop: **File → Clone repository → GitHub.com tab** → pick your new repo → choose a local folder (e.g., `Documents/GitHub/`) → **Clone**.
+   *Confirm:* the brief is committed before any modeling begins. The commit timestamp is what makes
+   it a hypothesis rather than a summary.
 
-### 3c. Build the skeleton
+9. **Commit and push.** At least two commits, each with a message saying what changed —
+   `Add portfolio skeleton and gitignore`, then `Add perfect-competition brief with mix hypothesis`.
+   *Confirm:* the files are visible on github.com, not only on your machine.
 
-This is the structure you keep. Nothing in it is named after a class:
+## 6. AI use
 
-```
-firstname-lastname/
-├── README.md                 # ← who you are + your index of engagements
-├── RESUME.md                 # ← Markdown resume; rough is fine on day one
-├── AGENTS.md                 # ← your AI conventions (canonical)
-├── CLAUDE.md                 # ← one line: "See AGENTS.md."
-├── prompt-log.md             # ← running record of AI sessions that mattered
-├── .gitignore                # ← Office/OS junk filter (Step 3d)
-├── skills/                   # ← THE QUIVER: one folder per capability (Stage 2 fills the first)
-├── docs/
-│   ├── briefs/               # ← BEFORE the work: scope + hypothesis
-│   │   └── perfect-competition-brief.md   # ← Step 4
-│   └── decisions/            # ← AFTER the work: recommendations to an audience
-└── analysis/                 # ← findings + figures/ (Stage 3 fills these)
-```
+| Artifact | Draft order |
+|---|---|
+| Repository skeleton, `.gitignore`, the `AGENTS.md` starting point | AI-first, verified |
+| `README.md` bio, `RESUME.md` | AI-first, verified — then edited until it sounds like you |
+| `docs/briefs/perfect-competition-brief.md` | Human-first |
 
-Two distinctions make the whole thing legible, and they are worth ten seconds each:
+**If the artifact is evidence of your judgment, you draft it first and AI reviews; if the artifact is
+a means to the work rather than the work itself, AI may draft it and you verify.** The two working
+loops are described in [AI conventions](https://adamwstauffer.github.io/ai-lms/ai-conventions.html).
 
-- **Briefs ask; memos answer.** `docs/briefs/` holds the engagement letter you write before you know anything. `docs/decisions/` holds what you hand the client at the end.
-- **Skills are capabilities; engagements are evidence.** `skills/marginal-analysis/` (built next stage) is a thing you can *do*. `docs/`, `analysis/`, and `data/` hold the work that proves you did it. Each skill folder's README names the engagements that exercised it — that link, claim to proof, is the line a reader actually follows.
+**For this stage specifically:** AI may explain the case's economics and argue against your
+reasoning; it may not write the brief. A hypothesis you did not generate cannot be honestly compared
+against results in Stage 3, and that comparison is the point. The other failure here is committing
+generic AI-written filler as your bio — it is obvious to any reader, and it is the first thing anyone
+sees.
 
-**About `skills/` vs `.claude/skills/`:** top-level `skills/` is *your* word, the one that goes on a resume — capabilities, written for humans. `.claude/skills/` is a tool-specific folder some AI tools read; you may create it and experiment freely, and nothing in this course grades it. They look similar on purpose: a capability folder is close enough to that convention that you can drop one in later almost unchanged.
+## 7. Verification
 
-Replace the auto-generated `README.md` with a short professional bio — who you are, background, what you're working toward. 3–6 sentences is plenty, and it evolves all semester. Below it, start an **engagement index**: a short list linking each piece of work to its brief, analysis, and memo. That index is the by-subject view of your repo; it lives in the README, never in the folder paths.
-
-`CLAUDE.md` is literally one line: `See AGENTS.md.` One source of truth, two filenames.
-
-`AGENTS.md` is where you write down how you want AI to work with you. A workable start — edit until it's yours:
-
-```markdown
-# AI conventions
-
-## How I work
-- Explain concepts fully; walk the worked example. Don't hand me conclusions.
-- Critique my reasoning hard. I'd rather be corrected than agreed with.
-
-## Boundaries
-- You may explain, critique, debug, and quiz me.
-- You may NOT write my briefs, analyses, memos, or reflections.
-- Every statistic or figure you give me is a draft until I verify it against a source.
-
-## Records
-- Sessions that mattered go in prompt-log.md: date, tool, what I asked,
-  what I got, what I did with it.
-```
-
-Drafting the bio, resume, or `AGENTS.md` with an LLM is fine; committing generic filler is not.
-
-> Git will not track an empty folder. To create `skills/` and `analysis/` now, drop a one-line `README.md` in each (`Capability folders live here.`) — or wait and create them in Stages 2 and 3, when they get real contents. Either is fine.
-
-### 3d. Add a `.gitignore`
-
-Excel and your OS both spawn hidden temp files you do **not** want in your history — and once junk lands in commits, getting it out is painful. Before your first workbook commit (Stage 2), create a file named `.gitignore` at the repo root (the leading dot is required; on Windows, save it from a text editor with quotes around the name: `".gitignore"`) containing:
-
-```
-# Excel and Office temp files
-~$*.xlsx
-~$*.xls
-~$*.docx
-~$*.pptx
-
-# OS junk
-.DS_Store
-Thumbs.db
-
-# Editor backups
-*.tmp
-*.bak
-```
-
-If you ever see `~$model.xlsx` in GitHub Desktop's Changes panel, your `.gitignore` is missing or misnamed — re-check.
-
-### 3e. Add your instructor as a collaborator
-
-The repo is public, so anyone can read it. Collaborator access is a different thing: it lets me push a review branch or open a pull request against your work instead of emailing you a paragraph.
-
-On your repo page: **Settings → Collaborators → Add people** → add **`adamwstauffer`**. The invitation shows as pending until it's accepted; you don't need to wait on it.
-
-### 3f. Commit and push
-
-In GitHub Desktop: your new files appear in the **Changes** panel → write a summary (`Add portfolio skeleton and gitignore` — descriptive, not `update`) → **Commit to main** → **Push origin**. Refresh the repo on github.com and confirm everything is there.
-
-## Step 4 — Write the brief
-
-Create `docs/briefs/perfect-competition-brief.md`. Read the [case README](README.md) first — the scenario, the assumptions table, the constraints. Then, **before touching Solver or the workbook**, write roughly half a page to a page:
-
-1. **The problem in your own words.** What is the farm deciding, what's fixed, what's chosen, what limits the choice? If you can't state it without re-reading the case, you don't have it yet.
-2. **Your hypothesis:** *"I expect the optimal mix to be X because Y."* Actual numbers — beds of tomatoes, carrots, mesclun — and actual reasoning (prices? labor intensity? the diminishing-returns percentages? the bed caps?). You will not be graded on being *right*; you will be graded on whether the guess is genuine and the reasoning is economic. "I expect a balanced mix because diversification" earns nothing.
-
-Commit and push it: `Add perfect-competition brief with mix hypothesis`.
-
-**AI note for this stage:** AI may critique your reasoning or explain concepts from the case — it may not write the brief. The hypothesis has to be yours; a hypothesis you didn't generate can't be honestly compared against results in Stage 3.
-
----
-
-## What to submit
-
-Submit your repo URL via Lamaku. The repo must contain:
-
-- [ ] Public visibility (URL opens without logging in)
-- [ ] `README.md` with a short professional bio + the start of an engagement index
-- [ ] `AGENTS.md` with your own conventions, and `CLAUDE.md` pointing at it
-- [ ] `.gitignore` covering Office/OS temp files
-- [ ] `docs/briefs/perfect-competition-brief.md` — problem restatement + genuine "X because Y" hypothesis
+- [ ] Repository is **public** — the URL opens in a private browser window without logging in
+- [ ] Named for you (`firstname-lastname`), not for a course
+- [ ] `README.md` holds a real three-to-six-sentence bio and the start of an engagement index
+- [ ] `AGENTS.md` written in your own words; `CLAUDE.md` is the one-line pointer
+- [ ] `RESUME.md` and `prompt-log.md` exist at the root — rough is acceptable
+- [ ] `.gitignore` filters Office and OS temp files
+- [ ] `docs/briefs/perfect-competition-brief.md` restates the problem in your voice
+- [ ] The hypothesis names a specific mix **and** the mechanism behind it
+- [ ] The brief was committed **before** any modeling work started
 - [ ] `adamwstauffer` invited as a collaborator
-- [ ] At least 2 commits with descriptive messages
+- [ ] At least two commits, each with a message that says what changed
 
----
-
-> **Post-deadline revision sweep.** After this stage's due date, I'll re-run the rubric against your repo state. Improvements you commit — a sharper hypothesis, a real bio, a fixed `.gitignore` — can move your score up; the full rubric applies, no cap on the bump. You don't need to email or open an issue; just revise the files in your repo. One sweep per stage; the score locks once the sweep runs.
-
----
-
-## Rubric (3 pts)
+## 8. Rubric (3 pts)
 
 | Criterion | Pts | What distinguishes strong work |
-|-----------|-----|-------------------------------|
-| Repo live + public, professionally named | 1 | URL works without login; `firstname-lastname` naming; bio README isn't placeholder text |
-| Skeleton + `.gitignore` + commit hygiene | 1 | `docs/briefs/` in place and the root files present (`AGENTS.md`, `CLAUDE.md`, `RESUME.md`, `prompt-log.md`); junk files filtered; ≥2 descriptive commits |
+|---|---|---|
+| Repo live and public, professionally named | 1 | URL works without login; `firstname-lastname` naming; the bio in `README.md` is not placeholder text |
+| Skeleton, `.gitignore`, and commit hygiene | 1 | `docs/briefs/` in place and the root files present (`AGENTS.md`, `CLAUDE.md`, `RESUME.md`, `prompt-log.md`); junk files filtered; at least two descriptive commits |
 | Brief quality — genuine hypothesis | 1 | Problem restated accurately in your own voice; hypothesis names a specific mix with economic reasoning, written before any Solver work |
 
----
+## 9. Common failure modes
 
-## Tips
+| What goes wrong | The correction |
+|---|---|
+| The repository is private, so nothing in it can be read | Settings → General → Change visibility → Public, then test the URL in a private window |
+| The repository is named after the course | Rename it now, while nothing links to it — a course-shaped repository stops meaning anything at graduation |
+| The hypothesis is hedged: "a balanced mix, because diversification" | Name quantities and a mechanism; a prediction that survives every outcome is not a prediction |
+| The brief is written after the workbook | There is no recovery — the Stage 3 comparison is gone. Write it first, even badly |
+| Empty directories disappear on push | Git tracks files, not folders; put a one-line `README.md` in each |
+| An hour spent polishing the bio on day one | It evolves all term. Get the repository live |
+| Commit messages read `update` | Say what changed: `Add brief: predicting tomato-heavy mix on price per bed` |
 
-- **Don't polish the bio.** It evolves all semester — Stage 1 is about getting the repo live.
-- **A wrong hypothesis is a good hypothesis.** The gap between your guess and Solver's answer is the raw material for Stage 3. The only bad hypothesis is a hedged one.
-- **Commit messages are graded habit.** Not `update` or `stuff` — say what changed: `Add brief: predicting tomato-heavy mix on price per bed`.
-- **Name files for the engagement, not the week.** `perfect-competition-brief.md` will still make sense to a stranger in three years. `week1.md` won't.
-- **Stuck on setup?** The [MBA GitHub guide](../../../../../docs/guides/github-mba-guide.md) covers every failure mode we've seen; check it before emailing.
+## 10. References
+
+- [Portfolio repo standard](https://adamwstauffer.github.io/ai-lms/portfolio-repo.html) · [AI conventions](https://adamwstauffer.github.io/ai-lms/ai-conventions.html) · [Deliverable templates](https://adamwstauffer.github.io/ai-lms/deliverable-templates.html)
+- [Git mechanics](https://adamwstauffer.github.io/ai-lms/onboarding.html#git-mechanics), including [`.gitignore`](https://adamwstauffer.github.io/ai-lms/onboarding.html#gitignore) and [how work is submitted, with the post-deadline revision policy](https://adamwstauffer.github.io/ai-lms/onboarding.html#submitting)
+- [`docs/guides/github-mba-guide.md`](../../../../../docs/guides/github-mba-guide.md) — the long-form Git reference, for troubleshooting
+- [Case README](README.md) — scenario, assumptions, constraints

--- a/courses/Micro-And-Macro-Economics/projects/in-progress/perfect-competition-marginal-costs/stage2-model-build.md
+++ b/courses/Micro-And-Macro-Economics/projects/in-progress/perfect-competition-marginal-costs/stage2-model-build.md
@@ -1,106 +1,198 @@
+---
+template: stage-brief
+project: perfect-competition-marginal-costs
+stage: 2
+title: "Model Build"
+capability: marginal-analysis
+deliverables:
+  - path: skills/marginal-analysis/model.xlsx
+    format: xlsx
+    ai_boundary: human-first
+  - path: skills/marginal-analysis/spec.md
+    format: markdown
+    ai_boundary: human-first
+  - path: skills/marginal-analysis/README.md
+    format: markdown
+    ai_boundary: human-first
+prerequisites: [1]
+points: 8
+estimated_time: "3-4 hrs"
+---
+
 # Case 1 · Stage 2 — Model Build
 
-**Case weight:** 10% of course grade — this stage: 8 of 20 pts
-**Format:** Upload-only — no presentation component
-**Deliverable:** `skills/marginal-analysis/model.xlsx` + `skills/marginal-analysis/spec.md` + `skills/marginal-analysis/README.md`, committed to your repo
-**Due:** end of Week 2 — exact dates on the course calendar (Case 1 spans Weeks 1–2, Aug 24–Sep 4)
+**Deliverable:** `skills/marginal-analysis/model.xlsx`, `spec.md`, and `README.md`
+**Submission:** committed and pushed to your public repository; graded by inspection
+**Estimated time:** 3–4 hours
 
 ---
 
-## Overview
+## 1. Purpose
 
-Build the model. Copy `farm-profit-optimizer-template.xlsx` (from the course repo, this folder) into your repo as **`skills/marginal-analysis/model.xlsx`**, then complete it: the cost structure, each crop's marginal-cost schedule, the P = MC read per crop, and a documented Solver run that finds the profit-maximizing mix under the real constraints.
+This stage produces the model: the cost structure, each crop's marginal-cost schedule, the P = MC
+read per crop, and a documented Solver run that finds the profit-maximizing mix under the real
+constraints. It also produces the spec that makes the run reproducible by somebody else. Getting the
+machinery right is the whole job here — *why* the answer looks the way it does is Stage 3.
 
-This is the supply side of perfect competition made mechanical — the farm is a price taker, every extra bed costs more labor than the last, and the question is where rising MC meets a flat price line. Get the machinery right here; *why* the answer looks the way it does is Stage 3's job.
+## 2. Prerequisites
 
-All scenario assumptions — prices, wages, bed caps, the labor function — are in the [case README](README.md). Do not invent numbers; the workbook's blue input cells and the README's assumptions table are the same set.
+- Stage 1 complete: the repository exists, and `docs/briefs/perfect-competition-brief.md` is
+  committed with your hypothesis in it, before this stage's work begins.
+- `farm-profit-optimizer-template.xlsx`, in this folder, copied into your repository as
+  `skills/marginal-analysis/model.xlsx`.
 
-### Why the model lives in `skills/`, not in a course folder
+Read before starting:
 
-`marginal-analysis` is a **capability** — the thing you can now do: take a decision with a rising cost curve and find where the next unit stops paying for itself. It is not "the farm assignment." That's why the folder is named for the method and why the spec and the workbook sit in it together: a method and the model that implements it are one object, and filing them apart is structure with no payoff.
+- The [case README](README.md) — all scenario assumptions: prices, wages, bed caps, the labor
+  function. Do not invent numbers; the workbook's blue input cells and the README's assumptions table
+  are the same set.
+- The template's own README sheet — the authoritative walkthrough of conventions, the color key, and
+  the Solver steps.
+- [The portfolio repo standard](https://adamwstauffer.github.io/ai-lms/portfolio-repo.html) — why the spec and the model live together in the capability folder.
 
-The farm is the **engagement** that exercises the capability, and its evidence lives elsewhere — the brief you wrote in `docs/briefs/`, the analysis you'll write in `analysis/`. The skill folder's `README.md` is the join between the two.
+## 3. Deliverables
 
-That structure pays off in Case 2 (`skills/pricing-power/`) and Case 3 (`skills/economic-profit/`), and again the first time somebody who is deciding whether to hire you reads the repo.
+| Artifact | Path | Format |
+|---|---|---|
+| The completed workbook | `skills/marginal-analysis/model.xlsx` | xlsx |
+| The model spec, including the documented Solver run | `skills/marginal-analysis/spec.md` | markdown |
+| What the capability is, and where it was exercised | `skills/marginal-analysis/README.md` | markdown |
 
-## What to complete in the workbook
+## 4. Background
 
-The template's README sheet is the authoritative walkthrough (conventions, color key, Solver steps). In outline:
+`marginal-analysis` is a **capability** — take a decision with a rising cost curve and find where the
+next unit stops paying for itself. It is not "the farm assignment." That is why the folder is named
+for the method, and why the spec and the workbook sit in it together: a method and the model that
+implements it are one object, and filing them apart creates structure with no payoff.
 
-1. **Cost structure** — fixed costs, fertilizer per bed, and the labor function: hours for `q` beds = `q × hrs/wk/bed × 36 × (1 + dim%)^q`. The exponential term is the diminishing-returns engine; if your MC schedules come out flat, this is where you broke it.
-2. **MC schedules per crop** — bed-by-bed marginal cost for tomatoes, carrots, and mesclun on the MC Schedules sheet, with the MC-vs-price charts populating.
-3. **P = MC per crop** — identify where each crop's standalone MC crosses its price. Expect roughly **tomatoes ~10, carrots ~10, mesclun ~6 beds**. Note what you see in tomato MC around bed 6 — you'll explain it in Stage 3.
-4. **Solver run** — objective: maximize profit; changing cells: the three bed-count decisions; **method: GRG Nonlinear** with **integer** decisions; constraints exactly as listed on the workbook's README sheet (bed caps, 64 total beds, temp workers ≤ 4). All constraint-check cells green.
+The farm is the **engagement** that exercises the capability, and its evidence lives elsewhere — the
+brief in `docs/briefs/`, the analysis in `analysis/`. The capability's `README.md` is the join
+between the two. The same structure carries into the later engagements, and it is what a reader
+follows from a claim on your resume to the work that proves it.
 
-## `spec.md` — the model, written down
+Economically, this is the supply side of perfect competition made mechanical. The farm is a price
+taker, every additional bed of a crop costs more labor than the last, and the question is where
+rising marginal cost meets a flat price line.
 
-The Solver documentation that used to live in the workbook's notes area now lives in **`skills/marginal-analysis/spec.md`**, alongside the model. Same content, better address: a spec next to the workbook is a thing you can hand someone, reuse in Case 2, and reread in a year. A note buried in a spreadsheet cell is not.
+## 5. Procedure
 
-Half a page, no more. Cover:
+1. **Build the cost structure** — fixed costs, fertilizer per bed, and the labor function: hours for
+   `q` beds = `q × hrs/wk/bed × 36 × (1 + dim%)^q`. The exponential term is the diminishing-returns
+   engine.
+   *Confirm:* test at `q = 1`. One bed of tomatoes should cost `1 × 2.5 × 36 × 1.10` hours. If your
+   MC schedules come out flat, this is where it broke.
 
-- **What the model computes and how** — the labor function, the perm-then-temp costing convention, the blended-rate allocation. Name the input cells and any named ranges you rely on.
-- **The Solver run, reproducibly** — objective cell, changing cells, every constraint, method (GRG Nonlinear, integer), and the starting point you used. *A Solver run that isn't documented isn't reproducible, and unreproducible isn't a model.*
-- **How the model is validated** — which check figures you matched, and any hand calculation you used to prove a formula (q = 1 is the classic).
+2. **Build the MC schedules** — bed-by-bed marginal cost for tomatoes, carrots, and mesclun on the
+   MC Schedules sheet.
+   *Confirm:* the MC-versus-price charts populate for all three crops.
 
-Also create **`skills/marginal-analysis/README.md`** — three or four lines is the whole job: what the capability is, and an "exercised in:" line pointing at this engagement's brief and (after Stage 3) its analysis and memo.
+3. **Read P = MC per crop** — find where each crop's standalone marginal cost crosses its price.
+   *Confirm:* roughly **tomatoes ~10, carrots ~10, mesclun ~6 beds**. Note what tomato MC does around
+   bed 6; you explain it in Stage 3.
 
-## Check figures — verify yourself before submitting
+4. **Run Solver** — objective: maximize profit. Changing cells: the three bed-count decisions.
+   Method: **GRG Nonlinear** with **integer** decisions. Constraints exactly as listed on the
+   workbook's README sheet — bed caps, 64 total beds, temp workers ≤ 4.
+   *Confirm:* every constraint-check cell is green, and the run reproduces the check figures below.
 
-The answers are published so you can self-verify; the grade is for the *model that produces them*, not the numbers.
+5. **Write `spec.md`** — half a page, no more, covering three things:
+   - **What the model computes and how** — the labor function, the permanent-then-temporary costing
+     convention, the blended-rate allocation. Name the input cells and any named ranges you rely on.
+   - **The Solver run, reproducibly** — objective cell, changing cells, every constraint, method, and
+     the starting point you used. A Solver run that is not documented is not reproducible, and
+     something unreproducible is not a model.
+   - **How the model is validated** — which check figures you matched, and any hand calculation you
+     used to prove a formula. The `q = 1` test is the classic.
+
+   *Confirm:* somebody who has never seen your workbook could rerun the optimization from this file
+   alone.
+
+6. **Write `skills/marginal-analysis/README.md`** — three or four lines. What the capability is, and
+   an "exercised in:" line pointing at this engagement's brief, and after Stage 3 its analysis and
+   memo.
+   *Confirm:* the links resolve on github.com, not just locally.
+
+7. **Commit at least twice** with descriptive messages — one when the cost structure and MC schedules
+   work, one after the documented Solver run. Not `update xlsx`.
+   *Confirm:* if `~$model.xlsx` appears in your Changes panel, your `.gitignore` is broken; fix it
+   before committing.
+
+### Check figures — verify before submitting
+
+The answers are published so you can self-verify. The grade is for the model that produces them, not
+for the numbers.
 
 | Check | Value |
 |---|---|
 | Optimal mix | Tomatoes **10** / Carrots **20** / Mesclun **30** (60 beds) |
 | Season profit | **$42,762** |
-| Standalone P~MC points | Tomatoes ~10 · Carrots ~10 · Mesclun ~6 beds |
+| Standalone P ≈ MC points | Tomatoes ~10 · Carrots ~10 · Mesclun ~6 beds |
 
-If Solver lands elsewhere, your model has a bug — trace it (a common one: starting from 20/0/0 instead of 0/0/0 and watching GRG path-depend; try both). Matching numbers with broken formulas also won't survive inspection — the rubric reads the workbook, not the answer cell.
+If Solver lands elsewhere, the model has a bug — trace it. Matching the numbers with broken formulas
+will not survive inspection either; the rubric reads the workbook, not the answer cell.
 
-**Companion oracle:** the interactive [Farm Profit Lab](https://adamwstauffer.github.io/ai-lms/farmlab.html) is this same model made touchable. Drag the bed counts, watch MC cross price, sanity-check any intermediate value against it. If your spreadsheet and the lab disagree, believe the lab and find your formula error.
+**Companion oracle:** the interactive [Farm Profit Lab](https://adamwstauffer.github.io/ai-lms/farmlab.html)
+is this same model made touchable. Drag the bed counts, watch MC cross price, sanity-check any
+intermediate value. If your spreadsheet and the lab disagree, believe the lab and find your formula
+error.
 
-## Commit hygiene
+## 6. AI use
 
-At least **2 descriptive commits** for this stage — e.g., one when the cost structure and MC schedules work, one after the documented Solver run. Not `update xlsx`. If `~$model.xlsx` ever shows up in your Changes panel, your Stage 1 `.gitignore` is broken — fix it before committing.
+| Artifact | Draft order |
+|---|---|
+| `skills/marginal-analysis/model.xlsx` | Human-first |
+| `skills/marginal-analysis/spec.md` | Human-first |
+| `skills/marginal-analysis/README.md` | Human-first |
 
-## AI-use boundary (course standard)
+**If the artifact is evidence of your judgment, you draft it first and AI reviews; if the artifact is
+a means to the work rather than the work itself, AI may draft it and you verify.** The two working
+loops are described in [AI conventions](https://adamwstauffer.github.io/ai-lms/ai-conventions.html).
 
-AI may explain concepts, critique your reasoning, and help debug formulas. It may not write your brief, analysis, or reflection. Log the sessions that mattered — the prompt log is graded in Stage 3, and debugging sessions from this stage are exactly what belongs in it. Having AI hand you completed formulas you can't explain is self-sabotage: the Stage 3 analysis requires you to explain what every piece of this model is doing.
+**For this stage specifically:** AI may explain concepts, critique your reasoning, and help debug
+formulas — "why is my MR column falling twice as fast as my demand column?" is exactly what it is
+for. Having AI hand you completed formulas you cannot explain is self-sabotage, because Stage 3
+requires you to explain what every piece of this model does. Log the sessions that mattered; the
+prompt log is graded in Stage 3, and this stage's debugging sessions are precisely what belongs in
+it.
 
----
+## 7. Verification
 
-## What to submit
+- [ ] Workbook committed to `skills/marginal-analysis/model.xlsx`
+- [ ] Labor function verified by hand at `q = 1`
+- [ ] MC schedules and charts populated for all three crops
+- [ ] P ≈ MC located per crop and noted
+- [ ] Solver run: GRG Nonlinear, integer decisions, every constraint entered
+- [ ] All constraint-check cells green; no `#REF!`, `#DIV/0!`, or `#NAME?` anywhere
+- [ ] Check figures matched: 10/20/30 beds, $42,762
+- [ ] The MC dip located and noted for Stage 3 — do not explain it yet
+- [ ] `spec.md` covers model logic, the full Solver run, and how you validated it
+- [ ] `README.md` in the capability folder, with an "exercised in:" line
+- [ ] No hardcoded overrides of formulas anywhere in the workbook
+- [ ] At least two descriptive commits for this stage
 
-Commit the files to your repo — Stage 2 is graded by inspection. Nothing separate goes to Lamaku unless announced.
-
-- [ ] `skills/marginal-analysis/model.xlsx` — copied from the template, completed
-- [ ] All constraint-check cells green; no `#REF!` / `#DIV/0!` / `#NAME?` anywhere
-- [ ] `skills/marginal-analysis/spec.md` — model logic, the Solver run (objective, changing cells, constraints, method, start point), and how you validated it
-- [ ] `skills/marginal-analysis/README.md` — what the capability is + "exercised in:" pointing at this engagement
-- [ ] MC schedules + charts populated for all three crops
-- [ ] ≥2 descriptive commits for this stage
-
----
-
-> **Post-deadline revision sweep.** After this stage's due date, I'll re-run the rubric against your repo state. Improvements you commit — fixing a broken labor formula, completing the Solver documentation, cleaning error cells — can move your score up; the full rubric applies, no cap on the bump. No email needed; just revise and push. One sweep per stage; the score locks once the sweep runs.
-
----
-
-## Rubric (8 pts)
+## 8. Rubric (8 pts)
 
 | Criterion | Pts | What distinguishes strong work |
-|-----------|-----|-------------------------------|
+|---|---|---|
 | Cost structure + labor function correct | 2 | Blue inputs match the case assumptions; diminishing-returns exponent working; blended-wage convention followed |
 | MC schedules + P = MC per crop | 2 | Bed-by-bed MC correct for all three crops; standalone crossings identified (~10/~10/~6); charts populated |
-| Solver run correct + documented | 3 | GRG Nonlinear, integer decisions, all constraints from the README sheet; finds 10/20/30 at $42,762; objective/cells/constraints/method/start point written down in `spec.md` |
-| Workbook hygiene + commit hygiene | 1 | Checks green, no error cells, no hardcoded overrides of formulas; skill `README.md` present; ≥2 descriptive commits |
+| Solver run correct + documented | 3 | GRG Nonlinear, integer decisions, all constraints from the README sheet; finds 10/20/30 at $42,762; objective, cells, constraints, method, and start point written down in `spec.md` |
+| Workbook hygiene + commit hygiene | 1 | Checks green, no error cells, no hardcoded overrides of formulas; skill `README.md` present; at least two descriptive commits |
 
----
+## 9. Common failure modes
 
-## Tips
+| What goes wrong | The correction |
+|---|---|
+| MC schedules come out flat | The diminishing-returns exponent is missing or misapplied. Test the labor function at `q = 1` before anything else |
+| Labor costs are wrong by a consistent margin | Permanent hours are consumed before any temporary hours, and the P&L allocates labor at the *blended* rate. Mixing the two conventions is the most common structural bug |
+| Tomato MC falls around bed 6 and you "fix" it | The model is right — marginal cost is not guaranteed to be monotonic. Note it and explain it in Stage 3 |
+| Solver lands on a different mix | Try two starting points. 0/0/0 finds the optimum; 20/0/0 may not, and that path-dependence is worth one sentence in the spec |
+| The spec is written at the end | Every time you settle a convention, that is a line of `spec.md`. Reconstructing it afterwards is how details get lost |
+| `~$model.xlsx` appears in Changes | `.gitignore` is missing, misnamed, or in the wrong folder |
 
-- **Build the labor function first and test it at q = 1.** One bed of tomatoes should cost `1 × 2.5 × 36 × 1.10` hours. If that's wrong, everything downstream is wrong.
-- **Perm hours first, then temp.** The farmer's 720 field hours are consumed before any temp hours — and the P&L allocates labor at the *blended* rate. Mixing those two conventions is the most common structural bug.
-- **Don't fight the dip.** If tomato MC falls around bed 6 and then rises again, your model is *right* — MC isn't guaranteed monotonic. Note it, move on, explain it in 1c.
-- **Try two Solver starts.** 0/0/0 finds the optimum; 20/0/0 may not. That path-dependence is worth one sentence in your spec.
-- **Write the spec as you build, not after.** Every time you settle a convention, that's a line of `spec.md`. Reconstructing it at the end is how details get lost.
-- **The lab is faster than F9.** For "what happens if I add one more carrot bed?" questions, the [Farm Profit Lab](https://adamwstauffer.github.io/ai-lms/farmlab.html) answers in a drag; use it to build intuition, then confirm in your own workbook.
+## 10. References
+
+- [Case README](README.md) — assumptions, constraints, instructor notes
+- [Farm Profit Lab](https://adamwstauffer.github.io/ai-lms/farmlab.html) — the same model, interactive
+- [Portfolio repo standard](https://adamwstauffer.github.io/ai-lms/portfolio-repo.html) · [AI conventions](https://adamwstauffer.github.io/ai-lms/ai-conventions.html)
+- [Git mechanics](https://adamwstauffer.github.io/ai-lms/onboarding.html#git-mechanics), including [how work is submitted, with the post-deadline revision policy](https://adamwstauffer.github.io/ai-lms/onboarding.html#submitting)

--- a/courses/Micro-And-Macro-Economics/projects/in-progress/perfect-competition-marginal-costs/stage3-analysis.md
+++ b/courses/Micro-And-Macro-Economics/projects/in-progress/perfect-competition-marginal-costs/stage3-analysis.md
@@ -1,102 +1,198 @@
+---
+template: stage-brief
+project: perfect-competition-marginal-costs
+stage: 3
+title: "Analysis + Prompt Log"
+capability: marginal-analysis
+deliverables:
+  - path: analysis/perfect-competition-analysis.md
+    format: markdown
+    ai_boundary: human-first
+  - path: analysis/figures/
+    format: images
+    ai_boundary: not-permitted
+  - path: docs/decisions/perfect-competition-memo.md
+    format: markdown
+    ai_boundary: human-first
+  - path: prompt-log.md
+    format: markdown
+    ai_boundary: human-first
+prerequisites: [1, 2]
+points: 9
+estimated_time: "3-4 hrs"
+---
+
 # Case 1 · Stage 3 — Analysis + Prompt Log
 
-**Case weight:** 10% of course grade — this stage: 9 of 20 pts (analysis 6 + prompt log 3)
-**Format:** Upload-only — no presentation component
-**Deliverable:** `analysis/perfect-competition-analysis.md` (≥2 figures in `analysis/figures/`) + `docs/decisions/perfect-competition-memo.md` + an updated root `prompt-log.md`, all committed to your repo
-**Due:** end of Week 2 — exact dates on the course calendar (Case 1 spans Weeks 1–2, Aug 24–Sep 4)
-
-> **Where this fits in the engagement.**
-> **Input:** your Stage 1 `docs/briefs/perfect-competition-brief.md` (the hypothesis you're now testing) + your Stage 2 `skills/marginal-analysis/model.xlsx` (the evidence source — every number you cite comes from it).
-> **Output (this stage):** the analysis, the client memo, and an updated prompt log — closing out Case 1.
-> **Used by:** the in-class debrief, and Cases 2–3 — the analysis-over-a-model-you-built pattern repeats all semester, as does the prompt-log habit.
+**Deliverable:** the analysis with figures, the recommendation memo, and an updated prompt log
+**Submission:** committed and pushed to your public repository; graded by inspection
+**Estimated time:** 3–4 hours
 
 ---
 
-## Overview
+## 1. Purpose
 
-Stage 2 produced a number — 10/20/30, $42,762. Stage 3 is where the points actually live: explain *why* that's the answer, in economics, with your model's own evidence, and then tell the farmer what to do about it. A Solver output you can't explain is a coincidence you happen to have committed.
+Stage 2 produced a number. This stage produces the reason: an explanation of *why* that is the
+answer, in economics, using your own model's evidence — and then a recommendation written to the
+person who has to act on it. A Solver output you cannot explain is a coincidence you happen to have
+committed.
 
-Three files, and the split between the first two is the point:
+## 2. Prerequisites
 
-| File | What it is |
+- Stage 1: `docs/briefs/perfect-competition-brief.md` — the hypothesis you are now testing.
+- Stage 2: `skills/marginal-analysis/model.xlsx` — the evidence source. Every number you cite comes
+  from it.
+
+Read before starting:
+
+- [Deliverable templates](https://adamwstauffer.github.io/ai-lms/deliverable-templates.html) — the memo structure and the prompt-log format.
+
+## 3. Deliverables
+
+| Artifact | Path | Format |
+|---|---|---|
+| The evidence — what the model shows and why, for someone checking your work | `analysis/perfect-competition-analysis.md` | markdown |
+| At least two figures the analysis refers to | `analysis/figures/` | images |
+| The answer — what the farmer should do, for the farmer | `docs/decisions/perfect-competition-memo.md` | markdown |
+| The curated record of AI sessions, plus the reflection | `prompt-log.md` | markdown |
+
+**Briefs ask; memos answer.** You wrote the question in Stage 1; this is where you close it. The
+analysis is the file a reviewer audits; the memo is the file a decision-maker reads.
+
+## 4. Background
+
+Four things in this model are worth explaining, and together they are what the analysis has to
+cover.
+
+**Where marginal cost crosses price.** Tomatoes are the clean case — interior at 10 beds, MC $8,249
+at bed 10 against a price of $8,800, with bed 11 costing $9,391.
+
+**Which constraints bind, and what they are worth.** Carrots and mesclun stop at their bed caps with
+MC still *below* price: the constraint ends production, not the economics. One more carrot bed would
+add roughly **$352** of profit, one more mesclun bed roughly **$246**. Some constraints never bind at
+all — 64 total beds and 4 temporary workers are both slack.
+
+**The tomato MC dip at about 6 beds.** Marginal cost falls before it rises. The farmer's own field
+hours at $34.72/hr run out, marginal labor switches to temporary labor at $17.36/hr, and then
+diminishing returns push MC back up through the price line. This is the lesson that input prices bend
+the marginal-cost curve, and it is the most interesting thing in the model.
+
+**Why growing loss-making crops is correct.** Standalone, every crop loses money at every quantity,
+because fixed costs dominate. The resolution is marginal cost against average *variable* cost: price
+exceeds AVC everywhere, so every bed contributes above variable cost, and the *mix* — not any single
+crop — is what turns a loss into $42,762. This is the short-run shutdown rule in farm clothes.
+
+## 5. Procedure
+
+1. **Write the analysis** at `analysis/perfect-competition-analysis.md`. One to two pages, covering
+   all four questions above from your own workbook's numbers.
+   *Confirm:* each claim points at a cell or a figure in your model, not at a textbook generalization.
+
+2. **Export at least two figures** into `analysis/figures/` — the MC-versus-price charts are the
+   obvious pair — and reference each one in the text.
+   *Confirm:* the images render on the github.com page, not merely in your editor. Relative links
+   are easy to get wrong.
+
+3. **Close the analysis against your hypothesis.** One honest paragraph: what you predicted, what the
+   model found, what your prior got right or wrong.
+   *Confirm:* the paragraph names a specific difference. Being wrong in the brief and precise about
+   why here is full-credit work.
+
+4. **Write the memo** at `docs/decisions/perfect-competition-memo.md`. Half a page, addressed to
+   whoever signs off on the plan — a partner, a lender, or you next February — with no jargon they
+   did not ask for. Three things belong in it:
+   - **The plan.** Plant 10 / 20 / 30, and one sentence of reasoning a non-economist would accept.
+   - **The judgment call.** Both caps bind, and one is worth more to relax than the other. Which
+     ground is worth spending money to expand first, and what is one more bed worth? That number came
+     out of your shadow-price work; here it becomes advice.
+   - **What would change your answer.** One line naming the variable the recommendation is most
+     sensitive to.
+
+   *Confirm:* it takes under twenty minutes to write. If it takes longer, the analysis has not
+   finished its job — that is a signal, not a writing problem.
+
+5. **Update `prompt-log.md`** at the repository root — a dated section for this engagement, not a new
+   file. Log the sessions that *mattered*: where AI explained something, caught or introduced an
+   error, or pushed your reasoning. Date, tool, what you asked, what you got, what you did with it.
+   *Confirm:* it is a curated record, not a transcript dump.
+
+6. **Write the reflection**, 300 words or fewer, at the end of the log: where AI helped, where it was
+   wrong, and — graded hardest — *how you verified*.
+   *Confirm:* the verification is concrete. "It seemed right" is not verification; "I checked its MC
+   formula against the labor function at `q = 1` and it had dropped the exponent" is. If AI genuinely
+   made no error you could catch, document the checks that convinced you.
+
+7. **Update `skills/marginal-analysis/README.md`** so its "exercised in:" line points at the analysis
+   and the memo as well as the brief.
+   *Confirm:* the capability now links to all of its evidence.
+
+8. **Commit at least twice** with descriptive messages.
+
+## 6. AI use
+
+| Artifact | Draft order |
 |---|---|
-| `analysis/perfect-competition-analysis.md` | **The evidence.** What the model shows and why, with figures. Written for someone checking your work. |
-| `docs/decisions/perfect-competition-memo.md` | **The answer.** What the farmer should do, in half a page, written for the farmer. |
-| `prompt-log.md` (repo root) | The curated record of AI sessions + your reflection. |
+| `analysis/perfect-competition-analysis.md` | Human-first |
+| `docs/decisions/perfect-competition-memo.md` | Human-first |
+| `prompt-log.md` and the reflection | Human-first |
+| Figures | Exported from your own workbook — not generated |
 
-Briefs ask; memos answer. You wrote the question in Stage 1 — this is where you close it.
+**If the artifact is evidence of your judgment, you draft it first and AI reviews; if the artifact is
+a means to the work rather than the work itself, AI may draft it and you verify.** The two working
+loops are described in [AI conventions](https://adamwstauffer.github.io/ai-lms/ai-conventions.html).
 
-## `analysis/perfect-competition-analysis.md` — the optimal mix and *why* (6 pts)
+**For this stage specifically:** AI may explain concepts, critique your reasoning, and help debug
+formulas. It may not write the analysis, the memo, or the reflection. The line, concretely: asking AI
+to critique your draft explanation of the MC dip is in bounds and worth logging. Pasting the case in
+and asking for an analysis is out of bounds — and it shows, because AI-written analysis explains the
+textbook rather than *your workbook's* numbers.
 
-Aim for 1–2 pages plus **at least 2 figures** — charts exported or screenshotted from your workbook into `analysis/figures/` (MC-vs-price per crop is the obvious pair). Every figure earns its place by being *referenced in the text*; a decorative chart is worth nothing. Cover four things:
+## 7. Verification
 
-1. **P = MC evidence per crop.** Where does each crop's marginal cost cross its price, and how does that show up in the optimal mix? Tomatoes are the clean case — interior at 10 beds, MC $8,249 at bed 10 vs price $8,800, bed 11 would cost $9,391. Show the reader the crossing, don't just assert it.
-2. **Which constraints bind — and what they're worth.** Carrots and mesclun stop at their bed caps with MC still *below* price — the constraint, not economics, ends production. Use the shadow-price intuition: one more carrot bed would add roughly **$352** of profit (mesclun ~$246). Note which constraints are *slack* too — 64 beds and 4 temp workers never bind.
-3. **The tomato MC dip at ~6 beds.** MC falls before it rises — explain the mechanism: the farmer's expensive field hours ($34.72/hr) run out and marginal labor switches to cheaper temp labor ($17.36/hr), then diminishing returns push MC back up through the price line. This is the "input prices bend the MC curve" lesson; an analysis that ignores the dip has ignored the most interesting thing in the model.
-4. **"Grow carrots and mesclun at a loss?"** Standalone, every crop loses money at every quantity — fixed costs dominate. So why is growing them optimal? Resolve it with MC vs AVC: price exceeds average *variable* cost everywhere, so every bed contributes over variable cost, and the *mix* — not any single crop — is what turns a loss into $42,762. This is the short-run shutdown rule wearing farm clothes.
+- [ ] P = MC evidence shown per crop, from your model's own numbers
+- [ ] Binding caps identified, with shadow-price reasoning (~$352 carrots, ~$246 mesclun)
+- [ ] Slack constraints named — 64 beds and 4 temporary workers
+- [ ] The tomato MC dip explained by mechanism, not merely observed
+- [ ] The "grow at a loss?" paradox resolved with MC versus AVC
+- [ ] At least two figures in `analysis/figures/`, each referenced in the text
+- [ ] Figures render on the GitHub page, not just in your editor
+- [ ] Honest paragraph comparing the result against your Stage 1 hypothesis
+- [ ] Memo written: the plan, the judgment call, and what would change your answer
+- [ ] Prompt log updated with curated sessions and a reflection of 300 words or fewer
+- [ ] Reflection names something concrete you verified, and how
+- [ ] `skills/marginal-analysis/README.md` "exercised in:" line updated
+- [ ] At least two descriptive commits for this stage
 
-Close with one honest paragraph against your Stage 1 hypothesis: what you predicted, what the model found, what your prior got wrong or right. Being wrong in the brief and precise about *why* here is full-credit work.
-
-## `docs/decisions/perfect-competition-memo.md` — the planting recommendation
-
-Half a page, written to whoever has to sign off on the plan — a partner, a lender, or you next February — with no jargon they didn't ask for. The recommendation that used to close the analysis lives here instead, because that's the shape of the work: the analysis is the file a reviewer audits, the memo is the file a decision-maker reads.
-
-Three things belong in it:
-
-- **The plan.** Plant 10 / 20 / 30 — and one sentence of reasoning a non-economist would accept.
-- **The judgment call.** Both the carrot and mesclun caps bind, and one is worth more to relax than the other. Which ground is worth spending money to expand first, and what is one more bed worth? That number came out of your shadow-price work in the analysis — this is where it turns into advice.
-- **What would change your answer.** One line. If tomato prices fell 20%, if a fifth temp worker were available, if the caps lifted — name the variable your recommendation is most sensitive to.
-
-This memo carries no separate points; it is read together with the analysis under the "P = MC evidence + binding constraints" criterion, which already asks what a farmer should conclude from a binding cap. What changes is where that conclusion lives — and that it's written to a person, not to a rubric.
-
-## `prompt-log.md` — sessions + reflection (3 pts)
-
-Log the AI sessions that **mattered** — the ones where AI explained a concept, caught (or introduced) an error, or pushed your reasoning. Not a transcript dump; a curated record. For each session: date, tool, what you asked, what you got, what you did with it.
-
-The log lives at the repo root and accretes across all three engagements — add a dated section for this one rather than starting a new file.
-
-Then a **reflection, ≤300 words**: where AI helped, where it was wrong, and — the part that's graded hardest — *how you verified*. "It seemed right" is not verification; "I checked its MC formula against the labor function at q = 1 and it had dropped the exponent" is. If AI genuinely made no error you could catch, document the verification that convinced you it hadn't — "the AI was flawless" without evidence of checking reads as "I didn't look."
-
-## AI-use boundary (course standard)
-
-AI may explain concepts, critique your reasoning, and help debug formulas. It may not write your brief, analysis, memo, or reflection. Log the sessions that mattered.
-
-The line for this stage, concretely: asking AI to critique your draft explanation of the MC dip is in-bounds and worth logging. Pasting the case in and asking for an analysis is out-of-bounds — and it shows, because AI-written analysis explains the textbook, not *your workbook's* numbers.
-
----
-
-## What to submit
-
-Commit all three files to your repo — Stage 3 is graded by inspection. Nothing separate goes to Lamaku unless announced.
-
-- [ ] `analysis/perfect-competition-analysis.md` — ≥2 figures, all four questions addressed, hypothesis revisited
-- [ ] Figure image files in `analysis/figures/` (relative links that render on GitHub — check the rendered page, not just your editor)
-- [ ] `docs/decisions/perfect-competition-memo.md` — the plan, the judgment call on which cap to relax, what would change your answer
-- [ ] `prompt-log.md` updated — meaningful sessions + ≤300-word reflection
-- [ ] `skills/marginal-analysis/README.md` "exercised in:" line updated to point at the analysis and memo
-- [ ] ≥2 descriptive commits for this stage
-
----
-
-> **Post-deadline revision sweep.** After this stage's due date, I'll re-run the rubric against your repo state. Improvements you commit — a figure that actually shows the P = MC crossing, a sharper shutdown-rule paragraph, a reflection with real verification steps — can move your score up; the full rubric applies, no cap on the bump. No email needed; just revise and push. One sweep per stage; the score locks once the sweep runs.
-
----
-
-## Rubric (9 pts)
+## 8. Rubric (9 pts)
 
 | Criterion | Pts | What distinguishes strong work |
-|-----------|-----|-------------------------------|
-| P = MC evidence + binding constraints | 3 | Crossings shown from *your* model's numbers; carrot/mesclun caps identified as binding with ~$352/~$246 shadow-price reasoning; slack constraints named; the memo turns that into a recommendation the farmer could act on |
-| MC dip + at-a-loss resolution | 2 | Dip mechanism (perm→temp wage switch) explained, not just observed; MC-vs-AVC shutdown logic resolves the "loss-making" crops correctly |
-| Figures + hypothesis revisit | 1 | ≥2 figures referenced in text and rendering on GitHub; honest comparison against the Stage 1 hypothesis |
-| Prompt log + reflection | 3 | Sessions curated, not dumped; reflection ≤300 words with concrete instances of AI being wrong and *how you verified* (or, if nothing was caught, the checks that cleared it) |
+|---|---|---|
+| P = MC evidence + binding constraints | 3 | Crossings shown from *your* model's numbers; carrot and mesclun caps identified as binding with ~$352 / ~$246 shadow-price reasoning; slack constraints named; the memo turns that into a recommendation the farmer could act on |
+| MC dip + at-a-loss resolution | 2 | Dip mechanism (permanent-to-temporary wage switch) explained, not just observed; MC-versus-AVC shutdown logic resolves the loss-making crops correctly |
+| Figures + hypothesis revisit | 1 | At least two figures referenced in text and rendering on GitHub; honest comparison against the Stage 1 hypothesis |
+| Prompt log + reflection | 3 | Sessions curated, not dumped; reflection of 300 words or fewer with concrete instances of AI being wrong and *how you verified* — or, if nothing was caught, the checks that cleared it |
 
----
+The memo carries no separate points. It is read together with the analysis under the P = MC evidence
+and binding-constraints criterion, which already asks what a farmer should conclude from a binding
+cap. What changes is where that conclusion lives, and that it is written to a person rather than to a
+rubric.
 
-## Tips
+## 9. Common failure modes
 
-- **Write from your cells, not from the textbook.** "MC rises due to diminishing returns" is a lecture note; "carrot MC hits $1,742 at bed 20, still $352 under price — the cap binds" is analysis. Cite your own numbers.
-- **Write the memo last and write it fast.** If it takes more than twenty minutes, the analysis hasn't finished its job. A memo you struggle to write is a signal, not a writing problem.
-- **The dip is a gift.** It's the one place this model surprises people — the [Farm Profit Lab](https://adamwstauffer.github.io/ai-lms/farmlab.html) makes it visible in ten seconds of dragging the tomato slider. Watch it happen, then explain it.
-- **Screenshot figures are fine.** Nobody is grading chart aesthetics; they're grading whether the figure carries evidence your text uses.
-- **Log as you go.** Reconstructing the prompt log the night before produces exactly the generic mush the rubric can smell. A two-line entry per session, written at the time, is effortless.
+| What goes wrong | The correction |
+|---|---|
+| The analysis cites the textbook instead of the workbook | "MC rises due to diminishing returns" is a lecture note. "Carrot MC hits $1,742 at bed 20, still $352 under price — the cap binds" is analysis |
+| Figures are decorative | Every figure earns its place by being referenced in the text. An unreferenced chart is worth nothing |
+| Figures do not render on GitHub | Relative paths are case-sensitive and must be repository-relative. Check the rendered page |
+| The MC dip is ignored | It is the one place this model surprises people. An analysis that skips it has skipped the most interesting result |
+| The memo restates the analysis | A memo recommends. If it summarizes, the two documents have swapped jobs |
+| The prompt log is reconstructed the night before | It produces generic mush that is obvious to a reader. Two lines per session, written at the time, is effortless |
+| The reflection claims AI made no mistakes | Without evidence of checking, that reads as not having looked. Document the verification that cleared it |
+
+## 10. References
+
+- [Deliverable templates](https://adamwstauffer.github.io/ai-lms/deliverable-templates.html) — the memo structure and prompt-log format
+- [Farm Profit Lab](https://adamwstauffer.github.io/ai-lms/farmlab.html) — makes the MC dip visible in ten seconds of dragging
+- [AI conventions](https://adamwstauffer.github.io/ai-lms/ai-conventions.html) · [Portfolio repo standard](https://adamwstauffer.github.io/ai-lms/portfolio-repo.html)
+- [Git mechanics](https://adamwstauffer.github.io/ai-lms/onboarding.html#git-mechanics), including [how work is submitted, with the post-deadline revision policy](https://adamwstauffer.github.io/ai-lms/onboarding.html#submitting)
+- [Case README](README.md) — assumptions and check figures

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -45,6 +45,7 @@ In practice:
 
 ### Assignment & Project Templates
 
+- **[`stage-brief-template.md`](./stage-brief-template.md)** — **The stage brief.** Every stage brief in every course uses its frontmatter block and its ten sections, in order. Carries the enumerated ban list (course codes, weeks, dates, weights, LMS names, delivery mode) that keeps a brief semester-invariant, and a register table mapping conversational phrasing to its instructional replacement. Authored 2026-08-02; see `ai-lms/docs/decisions/2026-08-02-stage-brief-template-and-content-ownership.md`
 - **[`memo-template.md`](./memo-template.md)** — Executive memo (Stage 1 / Stage 2 deliverables)
 - **[`spec-template.md`](./spec-template.md)** — Technical specification (Stage 4 deliverables; originally authored for ratios analysis, adaptable to other model-driven projects)
 - **[`case-brief-template.md`](./case-brief-template.md)** — Case analysis brief (BUS-313, BUS-620)
@@ -62,7 +63,7 @@ Every Markdown template in this directory carries a YAML frontmatter block so hu
 
 ```yaml
 ---
-template: memo                    # one of: memo, spec, case-brief, prompt-log
+template: memo                    # one of: memo, spec, case-brief, prompt-log, stage-brief
 purpose: "Short description of what the template is for"
 audience: student                 # student | instructor | both
 fields_required: [list, of, fields, the, student, must, fill, in]
@@ -73,6 +74,29 @@ notes: "Optional caveats or adaptation notes"
 ```
 
 **Why frontmatter:** When a student (or an LLM in the BUS-629 Stage 4 spec-drafting workflow) is choosing which template to apply, they should not have to read the entire body to figure out what the template is for. The `purpose` and `fields_required` keys answer that question in one block.
+
+### Instantiated stage briefs
+
+A stage brief written *from* `stage-brief-template.md` carries a different block — the template's own frontmatter describes the template; an instantiated brief describes the assignment:
+
+```yaml
+---
+template: stage-brief
+project: perfect-competition-marginal-costs   # directory slug
+stage: 1                                      # INTEGER, numbered per case from 1
+title: "Repo + Brief"
+capability: marginal-analysis                 # the skills/<capability>/ folder; omit if none
+deliverables:                                 # the canonical path declaration
+  - path: docs/briefs/perfect-competition-brief.md
+    format: markdown
+    ai_boundary: human-first                  # per artifact: human-first | ai-first-verified | not-permitted
+prerequisites: [1, 2]                         # prior stages whose deliverables must exist; [] for the first
+points: 3                                     # must equal the rubric total
+estimated_time: "60-80 min"
+---
+```
+
+The `deliverables` block is the **canonical declaration** of the artifact paths. Downstream consumers — the Kumu stage page and the gate predicates in `ai-lms/website/assets/js/gates.js` — hold literal mirrors of it, each citing the brief it mirrors, and the match is verified at PR rather than resolved at runtime. Changing a path here means changing those mirrors in the same pull request.
 
 ---
 

--- a/docs/templates/stage-brief-template.md
+++ b/docs/templates/stage-brief-template.md
@@ -1,0 +1,214 @@
+---
+template: stage-brief
+status: draft
+purpose: "Authoring template for every stage brief in every course — fixed section order, fixed frontmatter, semester-invariant content only"
+audience: instructor
+instantiated_audience: student
+destination: "C:/GitHub/shidler/docs/templates/stage-brief-template.md"
+related:
+  - ../decisions/2026-08-02-stage-brief-template-and-content-ownership.md
+  - "C:/GitHub/shidler/docs/templates/README.md"
+---
+
+# Stage brief template
+
+Every stage brief, in every course, uses the frontmatter block and the ten sections below, in
+this order. Sections are never reordered, renamed, or dropped; a section with nothing to say is
+written as `_None for this stage._` so the omission is visible rather than accidental.
+
+Two rules govern the whole document:
+
+**Semester-invariant.** A brief is written once and reused every offering. Nothing that changes
+between offerings appears in it — see § Authoring rules for the enumerated ban list.
+
+**Self-contained.** A student who has never met the instructor, attended no session, and watched
+no recording must be able to complete the stage from this document plus the reference docs it
+links. No sentence may assume live instruction.
+
+---
+
+## Frontmatter
+
+Required on every instantiated brief. Extends the schema in `shidler/docs/templates/README.md`.
+
+```yaml
+---
+template: stage-brief
+project: {project-slug}          # directory slug, e.g. perfect-competition-marginal-costs
+stage: {n}                       # INTEGER, numbered per case from 1 — matches the filename
+title: "{Stage title}"           # e.g. "Engagement Brief"
+capability: {capability-slug}    # the skills/<capability>/ folder this stage builds or uses; omit if none
+deliverables:                    # THE path declaration — nothing else may introduce a path
+  - path: docs/briefs/{engagement}-brief.md
+    format: markdown
+    ai_boundary: human-first     # per artifact, not per stage
+  - path: skills/{capability}/model.xlsx
+    format: xlsx
+    ai_boundary: ai-first-verified
+prerequisites: [{stage-id}, ...] # prior stages whose deliverables must exist; [] for the first
+points: {n}                      # integer; must equal the rubric total
+estimated_time: "{n}–{m} min"
+---
+```
+
+| Field | Why it exists |
+|---|---|
+| `stage` | Integer, numbered **per case from 1** — the containing folder already scopes the case, so the filename does not encode it twice (`2026-08-02-pr-release-process-and-stage-naming.md`). |
+| `deliverables` | The canonical **declaration** of the artifact paths. Prose in the body may reference a path but never introduce one. |
+| `ai_boundary` | Sits on each deliverable, not on the stage — a repo skeleton and a falsifiable hypothesis produced in the same stage carry different boundaries. The § 6 stage-level line is derived from these values; the AI tutor consumes them per artifact. |
+| `prerequisites` | Makes the self-contained rule checkable, and names what progression gating keys on. |
+| `points` | Points are stable across offerings. Percentages, weights, and dates are not, and are banned from the body. |
+
+---
+
+## Body skeleton
+
+Everything below is the instantiated document. Bracketed text is a placeholder; HTML comments are
+authoring guidance and are deleted on instantiation.
+
+```markdown
+# {Project title} · Stage {n} — {Stage title}
+
+**Deliverable:** {one line — the artifact(s), by name}
+**Submission:** {invariant phrasing — see the submission reference; never name an LMS}
+**Estimated time:** {n}–{m} minutes
+
+---
+
+## 1. Purpose
+
+<!-- Two to three sentences. What this stage produces, and why it must happen before the next one.
+     No scene-setting, no lede, no "in this stage you will…". State the function of the work. -->
+
+## 2. Prerequisites
+
+<!-- Two lists, both checkable by the student before starting:
+     - Artifacts that must already exist (prior-stage deliverables, by path)
+     - Reference docs to have read (link into the reference layer)
+     First stage of a project: "None — this is the entry point," then the reference reading. -->
+
+## 3. Deliverables
+
+<!-- A table, generated from the frontmatter block. Nothing here may contradict it. -->
+
+| Artifact | Path | Format |
+|---|---|---|
+| {name} | `{path}` | {format} |
+
+## 4. Background
+
+<!-- ONLY the concept unique to this stage — the economics, the finance, the method being taught.
+     Anything a student needs in more than one course belongs in the reference layer and is linked,
+     not restated. If this section exceeds ~400 words, something invariant has leaked into it. -->
+
+## 5. Procedure
+
+<!-- Numbered steps, imperative voice. Each step: the action, then how to confirm it worked.
+     "Create X." not "Now we'll create X." No first-person plural. No "you'll notice that…".
+     A step whose verification is "ask the instructor" fails the self-contained rule. -->
+
+1. **{Action.}** {Detail.}
+   *Confirm:* {what the student should now see}
+
+## 6. AI use
+
+<!-- Derived from the per-deliverable `ai_boundary` values in frontmatter. One row per artifact. -->
+
+| Artifact | Draft order |
+|---|---|
+| `{path}` | {human-first | ai-first, verified | not permitted} |
+
+<!-- ONE sentence of fixed prose — the only text mandated verbatim in every brief. Everything else
+     about how the two loops work is invariant and lives in the reference layer, linked below. -->
+
+**If the artifact is evidence of your judgment, you draft it first and AI reviews; if the artifact
+is a means to the work rather than the work itself, AI may draft it and you verify.** The two
+working loops — human-first critique and AI-first verification — are described in
+[the AI conventions guide]({reference-layer-url}).
+
+**For this stage specifically:** {one or two sentences — what AI may and may not touch here, and
+why the boundary sits where it does.}
+
+## 7. Verification
+
+<!-- Self-check the student runs before submitting. Mirrors the rubric criteria but carries no
+     points and names no scores — it is a checklist, not a grade preview. -->
+
+- [ ] {checkable statement}
+
+## 8. Rubric ({n} pts)
+
+| Criterion | Pts | What distinguishes strong work |
+|---|---|---|
+| {criterion} | {n} | {the observable difference between adequate and strong} |
+
+<!-- Points must sum to the frontmatter `points`. Percentages of the course grade never appear. -->
+
+## 9. Common failure modes
+
+<!-- Replaces "Tips." Instructional register: name the mistake, then the correction.
+     Drawn from what actually goes wrong, not from generic advice. -->
+
+| What goes wrong | The correction |
+|---|---|
+| {mistake} | {what to do instead} |
+
+## 10. References
+
+<!-- Links into the reference layer and to the project README. No inline restatement.
+     One of these links is the submission reference, which also carries the post-deadline
+     revision-sweep policy — invariant text, so it is linked here and never restated. -->
+```
+
+---
+
+## Authoring rules
+
+### Banned from every stage brief
+
+Each of these changes between offerings, which is what makes a brief go stale:
+
+| Banned | Where it belongs |
+|---|---|
+| Course codes and course names (`BUS 620`, `FIN 321`, "this course") | The course README and the syllabus |
+| Section or population names (`VEMBA`, `DLEMBA`, "the EMBA section") | The course README |
+| Semester, year, calendar dates, week numbers | The course calendar |
+| Percentage weights of the course grade | The syllabus |
+| LMS names and upload paths | The submission reference, once |
+| Any sentence about how the class meets — kickoffs, live walkthroughs, screencasts, "we'll cover this in class", "bring a laptop" | Nowhere. The brief must stand without them. |
+| Instructor-specific identifiers in prose | The submission reference; `{instructor-handle}` in the brief if unavoidable |
+
+### Register
+
+Instructional, not conversational. The brief tells a student what to do and why it matters; it is
+not a transcript of the reasoning that produced it.
+
+| Rewrite | To |
+|---|---|
+| "Two things happen here, and both are deliberately small." | "This stage produces two artifacts." |
+| "`CLAUDE.md` is literally one line." | "`CLAUDE.md` contains a single line pointing to `AGENTS.md`." |
+| "…and once junk lands in commits, getting it out is painful." | "Files committed once remain in the repository history even after deletion; excluding them beforehand is the only clean option." |
+| "top-level `skills/` is *your* word, the one that goes on a resume" | "`skills/` names capabilities in your own terms, for human readers." |
+
+No first-person plural, no rhetorical questions, no asides about the course's design intent.
+Second person for instructions is correct and expected.
+
+### The path rule
+
+Deliverable paths are **declared** once, in frontmatter. The body's deliverables table renders that
+declaration. Downstream consumers — the website's gate predicates, the Kumu stage page, any future
+grading script — **mirror** it: they hold their own literal copies, each citing the brief it
+mirrors, and the match is verified at PR rather than resolved at runtime. **No document restates a
+path as an independent fact.** Where a path appears in prose, it is a reference to the declaration,
+not a second source of it.
+
+### Instantiation checklist
+
+- [ ] Frontmatter complete; `points` equals the rubric total; every deliverable carries an `ai_boundary`
+- [ ] All ten sections present and in order
+- [ ] Ban list grepped clean (course codes, weeks, dates, percentages, LMS, delivery mode)
+- [ ] § 4 Background under ~400 words and free of invariant material
+- [ ] Every § 5 step has a `*Confirm:*` line
+- [ ] § 6's table matches the frontmatter `ai_boundary` values, and the one fixed sentence appears verbatim
+- [ ] No path appears that is not in the frontmatter `deliverables` block
+- [ ] Self-contained test: a reader with no prior contact could finish the stage


### PR DESCRIPTION
Part B of the accepted [content-ownership decision](https://github.com/adamwstauffer/ai-lms/blob/main/docs/decisions/2026-08-02-stage-brief-template-and-content-ownership.md). Merge **before** the ai-lms PR — the reference pages the briefs link to ship there.

## New: `docs/templates/stage-brief-template.md`

Ten fixed sections plus YAML frontmatter, an enumerated ban list, and a register table mapping each conversational phrasing you flagged to its instructional replacement. `docs/templates/README.md` gains the row and the instantiated-brief schema, so there is one convention rather than two.

## Case 1's three briefs, converted

**Out — changes between offerings, belongs elsewhere:** course codes, section and population names, week numbers, calendar dates, percentage weights, LMS names, and every sentence assuming live instruction. Ban-list grep returns **zero** across all three files.

**Out — now has one owner:** repo setup, `AGENTS.md`, git mechanics, `.gitignore`, and the brief/memo templates are course-invariant; they live on the Kumu site and the briefs link them.

**Unchanged, deliberately:** rubric criteria and totals (3 / 8 / 9), the 20-point case total, every check figure (10/20/30, $42,762, ~10/~10/~6, $8,249 / $8,800 / $9,391, ~$352 / ~$246, $34.72 / $17.36), and the AI-use boundary. The conversion rearranges and links; it does not reprice.

**In:** per-deliverable `ai_boundary` in frontmatter, and a Common failure modes table replacing Tips. § 7 Verification in stages 2 and 3 was expanded to match the Kumu stage-page checklists item-for-item — the brief owns that list, the page mirrors it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ABgM3WZyWatdh7ykxWpU1
