### PR TITLE
BUS-620 Case 2: name the market, not the protagonist

### DIFF
--- a/courses/Micro-And-Macro-Economics/BUS-620/README.md
+++ b/courses/Micro-And-Macro-Economics/BUS-620/README.md
@@ -101,7 +101,7 @@ arc — competition → market power → where the profits hide:
 1. **Perfect Competition — Decision Analysis** (market-garden scenario): P = MC, Excel Solver.
    Capability `marginal-analysis`, engagement `perfect-competition`
    ([case + stage briefs](../projects/in-progress/perfect-competition-marginal-costs/))
-2. **Imperfect Competition — Pricing Power Analysis** (Monsanto GMO seed scenario): monopoly,
+2. **Imperfect Competition — Pricing Power Analysis** (GMO seed market scenario): monopoly,
    MR = MC, Lerner, deadweight loss. Capability `pricing-power`, engagement `imperfect-competition`
    ([case + stage briefs](../projects/in-progress/imperfect-competition-marginal-revenue/))
 3. **Economic Profit & Rent — Earnings Analysis** (ride-share scenario): accounting vs economic

--- a/courses/Micro-And-Macro-Economics/README.md
+++ b/courses/Micro-And-Macro-Economics/README.md
@@ -13,7 +13,7 @@ Microeconomic and macroeconomic theory applied to real-world business and policy
 
 - [`projects/individual-research/`](projects/individual-research/) — individual research paper with peer-review rubric
 - [`projects/team-research/`](projects/team-research/) — team case-study presentations
-- [`projects/in-progress/`](projects/in-progress/) — the three graded case projects with stage briefs (Farm Profit → Monsanto → Ride-Share; 10% each, Fall 2026); Case 1 released, Cases 2-3 pending instructor sign-off
+- [`projects/in-progress/`](projects/in-progress/) — the three graded case projects with stage briefs (Perfect Competition → Imperfect Competition → Economic Rent; 10% each, Fall 2026); Case 1 released, Cases 2-3 pending instructor sign-off
 
 ## Directory Contents
 

--- a/courses/Micro-And-Macro-Economics/projects/in-progress/README.md
+++ b/courses/Micro-And-Macro-Economics/projects/in-progress/README.md
@@ -18,7 +18,7 @@ in-progress/
 │   ├── README.md
 │   ├── rideshare-driver-economics-key.xlsx               instructor
 │   └── Supply_Invisible Hand_Ride Sharing template.xlsx   original (unchanged)
-├── imperfect-competition-marginal-revenue/               Monsanto and the GMO Seed Market
+├── imperfect-competition-marginal-revenue/               The GMO Seed Market
 │   ├── BUS 620 Case Study_ Imperfect Competition & Marginal Revenue.docx   original (unchanged)
 │   ├── Monoplostic Supply_Marginal Revenue_Optimize Profit v9.xlsx          original (unchanged)
 │   ├── Monsanto Case Study worksheet in class.xlsx                          original (unchanged)

--- a/courses/Micro-And-Macro-Economics/projects/in-progress/accounting-profit-economic-profit-economic-rent/README.md
+++ b/courses/Micro-And-Macro-Economics/projects/in-progress/accounting-profit-economic-profit-economic-rent/README.md
@@ -70,7 +70,7 @@ Student-facing web pages: [`case-economic-profit.html`](https://adamwstauffer.gi
 - **The draft's "141,615 licensed Yellow Cabs in NYC (2010)" is wrong** — NYC medallions numbered ~13,500 and were 13,587 from 2014–2018. Corrected everywhere; the big number likely conflated TLC-licensed *drivers/vehicles* across all classes.
 - Check figures (Excel key recalculates clean, matches hand math to the dollar): accounting $50,520 / $22,860 / $59,580 / $52,200; economic −$1,680 / −$3,240 / +$7,380 / +$1,680; medallion $1,028,571 / $300,000.
 - Sensitivity to run live in class: days/mo 30 → 22 (all verdicts flip deep negative for drivers); commission 25% → 30%; cab lease $3,000 → $1,500 (post-Uber world — watch the cab driver's economic profit and ask who the winner is *now*).
-- Cross-case links: the farmer's field time in the Perfect Competition case is the same opportunity-cost idea; the medallion's rent-behind-a-moat is Monsanto's patent in miniature (all three cases now share the moat→rent→entry arc).
+- Cross-case links: the farmer's field time in the Perfect Competition case is the same opportunity-cost idea; the medallion's rent-behind-a-moat is the seed patent in miniature (all three cases now share the moat→rent→entry arc).
 
 ## Bugs fixed vs the draft template (for Adam)
 

--- a/courses/Micro-And-Macro-Economics/projects/in-progress/imperfect-competition-marginal-revenue/README.md
+++ b/courses/Micro-And-Macro-Economics/projects/in-progress/imperfect-competition-marginal-revenue/README.md
@@ -1,4 +1,4 @@
-# BUS 620 Project: Imperfect Competition & Marginal Revenue — Monsanto and the GMO Seed Market
+# BUS 620 Project: Imperfect Competition & Marginal Revenue — The GMO Seed Market
 
 > **Status:** briefs converted to the stage-brief template and spec-driven 2026-08-03. Formalizes `BUS 620 Case Study_ Imperfect Competition & Marginal Revenue.docx`; the originals (`…v9.xlsx`, in-class worksheet) are preserved unchanged. `monsanto-seed-market-key.xlsx` is the instructor key. All narrative claims below were externally validated 2026-07-07; sources at bottom.
 >
@@ -6,7 +6,9 @@
 
 ## The pitch
 
-One company, two market structures. Selling **commodity (non-GMO) corn seed**, Monsanto is a price taker at $120/bag — produce until **P = MC**, earn a modest profit that entry will erode. Selling **patented Roundup Ready GMO seed**, Monsanto faces the whole market's downward-sloping demand — one more bag sold lowers the price on *every* bag, marginal revenue falls twice as fast as demand, and the rule becomes **MR = MC**. Same crop, same $130M of fixed costs — and an ~83× difference in profit. Students build both models, locate both optima, and put a dollar figure on what monopoly costs society.
+One company, two market structures. Selling **commodity (non-GMO) corn seed**, the seed company is a price taker at $120/bag — produce until **P = MC**, earn a modest profit that entry will erode. Selling **patented herbicide-tolerant GMO seed**, the same firm faces the whole market's downward-sloping demand — one more bag sold lowers the price on *every* bag, marginal revenue falls twice as fast as demand, and the rule becomes **MR = MC**. Same crop, same $130M of fixed costs — and an ~83× difference in profit. Students build both models, locate both optima, and put a dollar figure on what monopoly costs society.
+
+> **Naming convention (2026-08-03).** The protagonist is unnamed — **"the seed company"** — on every student-facing surface and in this README's narrative. The market stays named, quantified, and cited, and every real party survives in **Validated facts & sources** at the bottom. The identity is one click away and openly signposted; the case is anonymized, not concealed. Rule and rationale: `ai-lms/docs/decisions/2026-08-03-case-scenario-anonymization.md`.
 
 ## Learning goals
 
@@ -57,14 +59,14 @@ Student-facing web pages: [`case-imperfect-competition.html`](https://adamwstauf
 
 ## Discussion spine (from the draft, kept)
 
-- How did Roundup + Roundup Ready seeds change Monsanto's business environment and competitive landscape? (Complement lock-in: the herbicide sells the seed and vice versa.)
+- How did pairing a proprietary herbicide with a seed engineered to tolerate it change the firm's business environment and competitive landscape? (Complement lock-in: the herbicide sells the seed and vice versa.)
 - Patent enforcement (no replanting harvested seed) as the mechanism that *keeps* demand downward-sloping — without it, farmers' saved seed is competing supply.
 - Superweeds (glyphosate-resistant weeds from over-reliance) as a negative externality the private optimum ignores.
-- Bayer 2018: does merging the #1 seed company into a top agrochemical firm restore competition concerns the patent already raised? (DOJ answer: largest antitrust divestiture in U.S. history as the price of approval.)
+- The 2018 acquisition: does merging the #1 seed company into a top agrochemical firm restore competition concerns the patent already raised? (DOJ answer: largest antitrust divestiture in U.S. history as the price of approval.)
 
 ## Instructor notes & check figures
 
-- **Non-GMO:** Q\* = (120−1)/0.00003 = 3,966,667; profit $106.0M. Discussion: this is *short-run* — the docx's "long-run profits" question answers itself: free entry competes it toward zero, which is exactly why Monsanto needed the patent moat.
+- **Non-GMO:** Q\* = (120−1)/0.00003 = 3,966,667; profit $106.0M. Discussion: this is *short-run* — the docx's "long-run profits" question answers itself: free entry competes it toward zero, which is exactly why the seed company needed the patent moat.
 - **GMO:** Q\* = 524/0.0000154 = 34,025,974; P\* $297.03; MR = MC = $69.05 ✓; profit $8.785B. Markup 4.30×, Lerner 0.768 (implied demand elasticity at optimum ≈ 1.3 — students who know the markup rule can back it out).
 - **DWL:** ½ × (297.03 − 69.05) × (60.23M − 34.03M) ≈ $2.99B/yr.
 - All figures brute-force/algebra verified and match the Excel key to the dollar (zero formula errors on recalculation).

--- a/courses/Micro-And-Macro-Economics/projects/in-progress/imperfect-competition-marginal-revenue/stage1-model-build.md
+++ b/courses/Micro-And-Macro-Economics/projects/in-progress/imperfect-competition-marginal-revenue/stage1-model-build.md
@@ -59,9 +59,9 @@ Read before starting:
 
 ## 4. Background
 
-Selling **commodity non-GMO corn seed**, the firm is a price taker at $120 a bag: it produces until
-**P = MC**, and free entry will erode the profit. Selling **patented Roundup Ready GMO seed**, the
-same firm faces the whole market's downward-sloping demand. One more bag sold lowers the price on
+Selling **commodity non-GMO corn seed**, the seed company is a price taker at $120 a bag: it produces
+until **P = MC**, and free entry will erode the profit. Selling **the patented herbicide-tolerant GMO
+seed**, the same firm faces the whole market's downward-sloping demand. One more bag sold lowers the price on
 *every* bag, so marginal revenue falls at twice the slope of demand, and the rule becomes
 **MR = MC**. Same crop, same $130M of fixed costs — and roughly an 83-fold difference in profit.
 

--- a/courses/Micro-And-Macro-Economics/projects/in-progress/imperfect-competition-marginal-revenue/stage2-analysis.md
+++ b/courses/Micro-And-Macro-Economics/projects/in-progress/imperfect-competition-marginal-revenue/stage2-analysis.md
@@ -84,7 +84,7 @@ walk past.
 discussion spine: complement lock-in, where the herbicide sells the seed and the seed sells the
 herbicide; patent enforcement, which is what *keeps* demand downward-sloping, because without it
 farmers' saved seed is competing supply; glyphosate-resistant weeds as a negative externality the
-private optimum ignores; and the 2018 Bayer acquisition, where the price of approval was the largest
+private optimum ignores; and the 2018 acquisition, where the price of approval was the largest
 negotiated merger divestiture in U.S. history. Either side is defensible. A fence-sit is not.
 
 ## 5. Procedure

--- a/docs/templates/stage-brief-template.md
+++ b/docs/templates/stage-brief-template.md
@@ -177,6 +177,17 @@ Each of these changes between offerings, which is what makes a brief go stale:
 | LMS names and upload paths | The submission reference, once |
 | Any sentence about how the class meets — kickoffs, live walkthroughs, screencasts, "we'll cover this in class", "bring a laptop" | Nowhere. The brief must stand without them. |
 | Instructor-specific identifiers in prose | The submission reference; `{instructor-handle}` in the brief if unavoidable |
+| **The name of the scenario's protagonist firm** — the company the student is advising | The case README's references section, with its sources |
+
+**On the protagonist rule.** *Name the market, not the protagonist.* The market stays named,
+quantified, and cited — acreage shares, prices per bag, what a patent does to a demand curve. What
+is withheld is the identity of the firm being advised, and only in the narrative: the references
+section names every party, because a citation that will not name its parties is not a citation. Hold
+one noun consistently ("the seed company"); alternating between "the firm," "the company," and "the
+producer" reads as evasion where one noun reads as convention. A live company name goes stale on a
+slower clock than a week number but in the same way — brands are retired, deals are litigated, and
+the footnote gets longer every year. Rule and rationale:
+`ai-lms/docs/decisions/2026-08-03-case-scenario-anonymization.md`.
 
 ### Register
 


### PR DESCRIPTION
Content half of the anonymization pair. **Merge this before the ai-lms PR** — the website mirrors these briefs.

Implements `ai-lms/docs/decisions/2026-08-03-case-scenario-anonymization.md`, ratified 2026-08-03: **name the market, not the protagonist.**

## What changes

| File | Change |
|---|---|
| `stage1-model-build.md` | "patented Roundup Ready GMO seed" → "the patented herbicide-tolerant GMO seed"; opening noun is "the seed company" |
| `stage2-analysis.md` | "the 2018 Bayer acquisition" → "the 2018 acquisition" |
| Case 2 `README.md` | Title and narrative → "The GMO Seed Market"; new note stating the convention; **sources block untouched** |
| Case 3 `README.md` | "Monsanto's patent in miniature" → "the seed patent in miniature" |
| Subject `README.md` | "(Farm Profit → Monsanto → Ride-Share)" → concept-first names |
| `BUS-620/README.md` | "(Monsanto GMO seed scenario)" → "(GMO seed market scenario)" |
| `projects/in-progress/README.md` | Directory-tree label only |
| `docs/templates/stage-brief-template.md` | Ban list gains the protagonist rule + its rationale |

**Two student-facing sentences.** That is the entire student-visible surface of this change — the 08-02 rename and the 08-03 conversion had already rewritten Case 2's prose to say "the firm" almost everywhere. The rest is instructor-facing prose and stale cross-references.

## What deliberately does not change

**The sources block keeps every name** — Monsanto, Bayer, BASF, the DOJ press release. This is the boundary that makes the convention honest: the identity is one click away and openly signposted, so the case is anonymized, not concealed. A citation that will not name its parties is not a citation.

**The preserved original filenames stay** — `Monsanto Case Study worksheet in class.xlsx` and the v9 workbook are inputs of record. Renaming a preserved artifact makes it stop being one.

## One question the rule doesn't answer — your call

Two **rebuilt** instructor files still carry the name: `monsanto-in-class-worksheet.xlsx` and `monsanto-seed-market-key.xlsx`. They are not preserved originals, so the not-touched list does not cover them; they are also not student-facing, so the rule does not reach them either. I left them alone rather than decide it unilaterally.

My recommendation: **rename them** at some convenient point (`gmo-seed-market-key.xlsx`, `gmo-seed-in-class-worksheet.xlsx`) — otherwise a grep for the name in this repo keeps returning hits that are neither citations nor originals, and the next person cannot tell which category they are in. It is two `git mv`s and three prose references, and there is no hurry.

## Verification

- `grep -i monsanto` across the repo now returns only: the sources block (intended), the two preserved original filenames (intended), and the two rebuilt-file names above (flagged)
- No `points`, rubric row, check figure, deliverable path, or `ai_boundary` value moves
- Ban list, weight-free, and date-free constraints all still hold
- Check figures untouched: $2.99B/yr DWL, Q* = 34,025,974, P* = $297.03

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ABgM3WZyWatdh7ykxWpU1
