### PR TITLE
Offering READMEs: link the Kumu subject hub

### DIFF
--- a/courses/International-Corporate-Finance/BUS-629-VEMBA/README.md
+++ b/courses/International-Corporate-Finance/BUS-629-VEMBA/README.md
@@ -2,6 +2,8 @@
 
 **Vietnam Executive MBA Program** | Shidler College of Business, University of Hawai'i at Manoa
 
+**Course tutorials:** [International Corporate Finance on Kumu](https://adamwstauffer.github.io/ai-lms/international-corporate-finance.html) — the stage-by-stage tutorials, labs, and reference pages this course's projects assume. Kumu is organized by subject and carries no course codes; this README is the signpost from the code to the material.
+
 ## Course Overview
 
 This course develops students' understanding of corporate finance. It introduces financing and investment decision-making considerations and the securities available to financial managers. The course relies heavily on developing models using Microsoft Excel and applies a **spec-driven design** approach where students build financial models, write technical specifications, and critically evaluate LLM-generated analysis.

--- a/courses/International-Economics-And-Trade/BUS-313/README.md
+++ b/courses/International-Economics-And-Trade/BUS-313/README.md
@@ -2,6 +2,8 @@
 
 **Shidler College of Business, University of Hawaiʻi at Mānoa**
 
+**Course tutorials:** [International Economics & Trade on Kumu](https://adamwstauffer.github.io/ai-lms/international-economics-and-trade.html) — the stage-by-stage tutorials, labs, and reference pages this course's projects assume. Kumu is organized by subject and carries no course codes; this README is the signpost from the code to the material.
+
 ## Course Overview
 
 This course develops students' understanding of the global economic and financial environment of business. It introduces trade and international finance theory and applies it to real-world case studies across global regions.

--- a/courses/International-Finance-And-Securities/FIN-321/README.md
+++ b/courses/International-Finance-And-Securities/FIN-321/README.md
@@ -2,6 +2,8 @@
 
 **Shidler College of Business, University of Hawaiʻi at Mānoa**
 
+**Course tutorials:** [International Finance & Securities on Kumu](https://adamwstauffer.github.io/ai-lms/international-finance-and-securities.html) — the stage-by-stage tutorials, labs, and reference pages this course's projects assume. Kumu is organized by subject and carries no course codes; this README is the signpost from the code to the material.
+
 ## Course Overview
 
 The world economy is increasingly integrated. This course introduces fundamental concepts of international finance, including:

--- a/courses/Micro-And-Macro-Economics/BUS-620-DLEMBA/README.md
+++ b/courses/Micro-And-Macro-Economics/BUS-620-DLEMBA/README.md
@@ -2,6 +2,8 @@
 
 **Distance EMBA — Shidler College of Business, University of Hawaiʻi at Mānoa**
 
+**Course tutorials:** [Micro & Macro Economics on Kumu](https://adamwstauffer.github.io/ai-lms/micro-and-macro-economics.html) — the stage-by-stage tutorials, labs, and reference pages this course's projects assume. Kumu is organized by subject and carries no course codes; this README is the signpost from the code to the material.
+
 > **Status:** structured 2026-07-31 as an async clone of [BUS 620](../BUS-620/README.md) for the
 > Fall 2026 launch; revised 2026-08-02 alongside the on-campus section (individual 30% is now a
 > geopolitical research paper; case artifacts follow the portfolio-repo standard).

--- a/courses/Micro-And-Macro-Economics/BUS-620/README.md
+++ b/courses/Micro-And-Macro-Economics/BUS-620/README.md
@@ -2,6 +2,8 @@
 
 **Shidler College of Business, University of Hawaiʻi at Mānoa**
 
+**Course tutorials:** [Micro & Macro Economics on Kumu](https://adamwstauffer.github.io/ai-lms/micro-and-macro-economics.html) — the stage-by-stage tutorials, labs, and reference pages this course's projects assume. Kumu is organized by subject and carries no course codes; this README is the signpost from the code to the material.
+
 ## Course Overview
 
 This MBA-level course provides a comprehensive exploration of microeconomic and macroeconomic theories and their application to real-world business and policy challenges. Emphasis is placed on the intersection of economics, geopolitics, and global stability.


### PR DESCRIPTION
**Prerequisite for the Kumu course-code removal** (ai-lms `docs/decisions/2026-08-03-case-flow-and-chrome-review.md`, ruling A1). **Merge this before the ai-lms chrome PR.**

## Why

A1 removes every course code from the Kumu website and designates these offering READMEs as the replacement signpost: public, indexed, already titled with the code, one documented hop to the material.

Verifying that dependency, it did not hold — **none of the five offering READMEs linked its hub.** Merging the website change first would have left a student who searches their course code with no path to the material at all: the anchor removed from one place and never added to the other.

## What changed

A "Course tutorials" line directly under each README's institution line, naming the subject, linking the hub, and saying plainly why the code does not appear there.

| Offering | Hub |
|---|---|
| BUS 629 (VEMBA) | International Corporate Finance |
| BUS 313 | International Economics & Trade |
| FIN 321 | International Finance & Securities |
| BUS 620 | Micro & Macro Economics |
| BUS 620 DLEMBA | Micro & Macro Economics |

`BUS-314` has no README and no Kumu subject, so nothing was added there.

Nothing else in these READMEs changes — no points, dates, weights, or deliverable paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ABgM3WZyWatdh7ykxWpU1