### PR TITLE
BUS-620 Case 1: split Stage 1 into Stage 0 (repo) and Stage 1 (brief)

### DIFF
--- a/courses/Micro-And-Macro-Economics/BUS-620-DLEMBA/README.md
+++ b/courses/Micro-And-Macro-Economics/BUS-620-DLEMBA/README.md
@@ -68,7 +68,7 @@ presence, and it leaves you with a public portfolio artifact no discussion-board
 | **Total** | **100%** |
 
 Component details, the case structure (one accreting portfolio repo organized by capability and
-engagement, 20 points per case across 2–3 stages, published check figures), the shared deliverable
+engagement, 20 points per case across 2–4 stages, published check figures), the shared deliverable
 path table, and the geopolitical-paper scope are identical to the on-campus section — see
 [BUS 620 § Grading](../BUS-620/README.md#grading-fall-2026). Case materials and stage briefs live in
 [`../projects/in-progress/`](../projects/in-progress/).

--- a/courses/Micro-And-Macro-Economics/BUS-620/README.md
+++ b/courses/Micro-And-Macro-Economics/BUS-620/README.md
@@ -84,7 +84,7 @@ showing up and committing is participating.
 ### Case-Study Projects (3 × 10%)
 
 Three 2-week Excel + AI engagements, each worth 20 points split across 2–3 graded stages. One
-**personal public GitHub portfolio repo**, created in Case 1's first stage, accretes all term. It is
+**personal public GitHub portfolio repo**, created in Case 1's Stage 0, accretes all term. It is
 structured by **capability** and **engagement**, not by course — the full standard is in
 `ai-lms/docs/decisions/2026-08-02-website-simplification-and-portfolio-repo-standard.md` § 6. Each
 case adds a capability folder plus its evidence:
@@ -163,7 +163,7 @@ Instruction runs **2026-08-24 → 2026-12-10**; finals week 2026-12-14–18. Sta
 
 | Weeks | Dates | What's running |
 |---|---|---|
-| 1–2 | Aug 24 – Sep 4 | **Case 1 — Perfect Competition** (stage 1 repo + brief, 2 build, 3 analysis) |
+| 1–2 | Aug 24 – Sep 4 | **Case 1 — Perfect Competition** (stage 0 repo, 1 brief, 2 build, 3 analysis) |
 | 3–4 | Sep 8 – Sep 18 | **Case 2 — Imperfect Competition** (stage 1 build, 2 analysis) · Labor Day Sep 7 |
 | 5–6 | Sep 21 – Oct 2 | **Case 3 — Economic Profit & Rent** (stage 1 build, 2 analysis) |
 | 7–11 | Oct 5 – Nov 6 | **Geopolitical research paper** (proposal → draft → final) · macro units |

--- a/courses/Micro-And-Macro-Economics/projects/in-progress/README.md
+++ b/courses/Micro-And-Macro-Economics/projects/in-progress/README.md
@@ -1,7 +1,7 @@
 # Case Studies
 
 The three graded **BUS 620 case projects**: 20 points each, split across 2–3 staged deliverables
-into one accreting personal portfolio repo. Sequence: **Perfect Competition (3 stages — also stands
+into one accreting personal portfolio repo. Sequence: **Perfect Competition (4 stages — also stands
 up the repo) → Imperfect Competition → Economic Profit & Rent**, tracing competition → market power
 → where the profits hide. Course weights and the term calendar live in the offering README
 (`../../BUS-620/README.md`). Each folder holds the case README (scenario, check figures, instructor notes), the

--- a/courses/Micro-And-Macro-Economics/projects/in-progress/perfect-competition-marginal-costs/README.md
+++ b/courses/Micro-And-Macro-Economics/projects/in-progress/perfect-competition-marginal-costs/README.md
@@ -49,13 +49,26 @@ Capability slug for this case: **`marginal-analysis`**. Engagement slug: **`perf
 
 | # | Artifact (path in the student repo) | What it must contain | Pts |
 |---|---|---|---|
-| 1 | `docs/briefs/perfect-competition-brief.md` | The farm problem in your own words + a hypothesis: "I expect the optimal mix to be X because Y" — *before* touching Solver | 3 |
+| 0 | The portfolio repository itself — skeleton, four root files, `.gitignore`, instructor invited | The workspace every engagement lands in, built to the portfolio-repo standard and named for the student rather than the course | 2 |
+| 1 | `docs/briefs/perfect-competition-brief.md` | The farm problem in your own words + a hypothesis: "I expect the optimal mix to be X because Y" — *before* touching Solver | 1 |
 | 2 | `skills/marginal-analysis/spec.md` + `model.xlsx` + `README.md` | **Spec first**, before the workbook exists: named inputs with units and sources, calculation logic in named-range notation, and the published check figures written in as acceptance criteria. Then an AI builds from the spec, and the student audits the result — findings recorded in the spec | 8 |
 | 3 | `analysis/perfect-competition-analysis.md` + `analysis/figures/` | The optimal mix and *why*: P=MC evidence per crop, which constraints bind, the tomato MC dip explained, the carrot/mesclun "grow at a loss?" resolution (MC vs AVC, contribution over variable cost) | 6 |
 | 3b | `docs/decisions/perfect-competition-memo.md` | The recommendation to the farmer: the plan, which cap to relax first and what it's worth, what would change the answer. No separate points — read with the analysis | — |
 | 4 | `prompt-log.md` (repo root) + reflection | Meaningful AI sessions logged; ≤300-word reflection on where AI helped, where it was wrong, and how you verified | 3 |
 
-Split across stages: [stage1](stage1-repo-and-brief.md) (repo + brief, 3) · [stage2](stage2-model-build.md) (spec, build, audit, 8) · [stage3](stage3-analysis.md) (analysis + memo + log, 9).
+Split across stages: [stage0](stage0-portfolio-repo.md) (the repository, 2) ·
+[stage1](stage1-engagement-brief.md) (the brief, 1) · [stage2](stage2-model-build.md) (spec, build,
+audit, 8) · [stage3](stage3-analysis.md) (analysis + memo + log, 9). **Case total 20, unchanged.**
+
+> **Stage 0 split (2026-08-03).** The former `stage1-repo-and-brief.md` carried three separately
+> priced criteria: two about the repository and one about the brief. They are now two stages along
+> the seam that was already there — **every criterion keeps its exact point value, and no criterion
+> text was rewritten**. This is a regroup, not a repricing. Standing up the workspace and forming a
+> falsifiable hypothesis are different kinds of work with different AI boundaries, and a graded gate
+> between them is what makes the repository finished *before* the brief is written rather than
+> alongside it. The commit-order rule — brief before any modeling — stays on Stage 1, where the
+> thing it orders lives. Rationale: `ai-lms/docs/decisions/2026-08-03-case-flow-and-chrome-review.md`
+> § B1. Cases 2 and 3 keep two stages; only Case 1 stands up the repository.
 
 Student-facing web pages for this case: [`case-perfect-competition.html`](https://adamwstauffer.github.io/ai-lms/case-perfect-competition.html) and its three stage pages. **Sync rule:** these paths, the stage pages, and `ai-lms/website/assets/js/gates.js` share one path table — change one, change all three.
 

--- a/courses/Micro-And-Macro-Economics/projects/in-progress/perfect-competition-marginal-costs/stage0-portfolio-repo.md
+++ b/courses/Micro-And-Macro-Economics/projects/in-progress/perfect-competition-marginal-costs/stage0-portfolio-repo.md
@@ -1,36 +1,36 @@
 ---
 template: stage-brief
 project: perfect-competition-marginal-costs
-stage: 1
-title: "Repo + Brief"
+stage: 0
+title: "Portfolio Repository"
 capability: marginal-analysis
 deliverables:
   - path: "(repository) firstname-lastname"
     format: repo
     ai_boundary: ai-first-verified
-  - path: docs/briefs/perfect-competition-brief.md
-    format: markdown
-    ai_boundary: human-first
 prerequisites: []
-points: 3
-estimated_time: "60-80 min"
+points: 2
+estimated_time: "40-50 min"
 ---
 
-# Case 1 · Stage 1 — Repo + Brief
+# Case 1 · Stage 0 — Portfolio Repository
 
-**Deliverable:** the portfolio repository, and `docs/briefs/perfect-competition-brief.md` inside it
+**Deliverable:** the public portfolio repository, built to the standard, with the instructor invited
 **Submission:** committed and pushed to your public repository; graded by inspection
-**Estimated time:** 60–80 minutes
+**Estimated time:** 40–50 minutes
 
 ---
 
 ## 1. Purpose
 
-This stage produces two things: the public portfolio repository that every engagement lands in, and
-a one-page engagement brief stating the farm's problem in your own words and ending in a hypothesis
-you can be shown wrong about. Neither is analysis. Both are the conditions that make the analysis
-worth anything — and the brief has to exist before the model does, because Stage 3 compares what you
-predicted against what the model found, and that comparison cannot be reconstructed afterwards.
+This stage produces the workspace, and nothing else. One public repository, named for you, holding
+the structure that every engagement in this course and every engagement after it lands in. No
+analysis happens here.
+
+It is a stage of its own rather than a preamble to the brief because it has to be finished before
+the brief is written, and because it is the one artifact in this course that outlives the course. A
+repository stood up properly in week one is a portfolio by December; one thrown together on the way
+to a deadline is a folder of homework.
 
 ## 2. Prerequisites
 
@@ -41,8 +41,6 @@ Read before starting:
 - [The portfolio repo standard](https://adamwstauffer.github.io/ai-lms/portfolio-repo.html) — the structure, the four starter files, and a prompt that builds the skeleton
 - [AI conventions](https://adamwstauffer.github.io/ai-lms/ai-conventions.html) — what goes in `AGENTS.md`, and what must never be committed
 - [Git mechanics](https://adamwstauffer.github.io/ai-lms/onboarding.html#git-mechanics) — local versus remote, add → commit → push, `.gitignore`, and how work is submitted
-- [Deliverable templates](https://adamwstauffer.github.io/ai-lms/deliverable-templates.html) — the shape of a brief
-- The [case README](README.md) — scenario, assumptions table, constraints
 
 ## 3. Deliverables
 
@@ -53,24 +51,23 @@ Read before starting:
 | AI conventions, and the pointer to them | `AGENTS.md`, `CLAUDE.md` | markdown |
 | Resume and prompt log, started | `RESUME.md`, `prompt-log.md` | markdown |
 | Exclusion rules | `.gitignore` | text |
-| The engagement brief | `docs/briefs/perfect-competition-brief.md` | markdown |
 
 ## 4. Background
 
-A prediction written *before* the model runs is falsifiable. The same sentence written afterwards is
-a summary of the output, and it teaches you nothing, because you can no longer distinguish "I
-understood the economics" from "I read the answer cell."
+The repository is organized by **capability** and **engagement**, never by course. A folder named
+for a class stops meaning anything the moment the class ends, and a reader who opens
+`week3/final_v2.xlsx` learns nothing about what you can do. `skills/marginal-analysis/` names a
+capability; `docs/`, `data/`, and `analysis/` hold the work that proves you exercised it.
 
-This is not a classroom convention. It is why an analyst writes an engagement brief before opening
-the data, and why "we always thought so" is the least trustworthy sentence in business. A wrong
-hypothesis, precisely reasoned, is worth as much as a correct one and considerably more than a lucky
-one.
+Two consequences worth knowing before you start rather than after:
 
-What makes a hypothesis genuine is that some outcome would refute it. *"I expect roughly 15 tomato
-beds, 20 carrot, 25 mesclun, because tomatoes earn about four times what carrots do per bed and I
-doubt the labor penalty closes that gap"* names quantities and a mechanism, and the model can
-contradict it. *"I expect a balanced mix because diversification reduces risk"* would survive any
-result, which is what disqualifies it.
+**Git tracks files, not folders.** An empty directory does not survive a push. Every directory in
+the skeleton needs at least one file in it — a one-line `README.md` saying what belongs there is
+enough, and is more useful to a reader than an empty folder anyway.
+
+**History is permanent.** A file committed once stays in the repository's history even after it is
+deleted. That is why `.gitignore` goes in *before* the first workbook, not after the first
+accidental commit of a `~$` temp file.
 
 ## 5. Procedure
 
@@ -108,21 +105,8 @@ result, which is what disqualifies it.
    your work instead of an emailed paragraph.
    *Confirm:* the invitation shows as pending. You do not need to wait for it.
 
-8. **Write the brief** at `docs/briefs/perfect-competition-brief.md`, using the structure on the
-   deliverable-templates page. Read the [case README](README.md) first, then — **before opening the
-   workbook or Solver** — write half a page to a page covering two things:
-   - **The problem in your own words.** What the farm is deciding, what is fixed, what is chosen,
-     what limits the choice. If you cannot state it without re-reading the case, you do not have it
-     yet, and that is useful information about where the next hour goes.
-   - **Your hypothesis.** *"I expect the optimal mix to be X because Y."* Real quantities — beds of
-     tomatoes, carrots, mesclun — and real reasoning: prices per bed, labor intensity, the
-     diminishing-returns percentages, the caps. Name the mechanism you think decides it.
-
-   *Confirm:* the brief is committed before any modeling begins. The commit timestamp is what makes
-   it a hypothesis rather than a summary.
-
-9. **Commit and push.** At least two commits, each with a message saying what changed —
-   `Add portfolio skeleton and gitignore`, then `Add perfect-competition brief with mix hypothesis`.
+8. **Commit and push.** At least two commits, each with a message saying what changed —
+   `Add portfolio skeleton and gitignore` rather than `update`.
    *Confirm:* the files are visible on github.com, not only on your machine.
 
 ## 6. AI use
@@ -131,17 +115,17 @@ result, which is what disqualifies it.
 |---|---|
 | Repository skeleton, `.gitignore`, the `AGENTS.md` starting point | AI-first, verified |
 | `README.md` bio, `RESUME.md` | AI-first, verified — then edited until it sounds like you |
-| `docs/briefs/perfect-competition-brief.md` | Human-first |
 
 **If the artifact is evidence of your judgment, you draft it first and AI reviews; if the artifact is
 a means to the work rather than the work itself, AI may draft it and you verify.** The two working
 loops are described in [AI conventions](https://adamwstauffer.github.io/ai-lms/ai-conventions.html).
 
-**For this stage specifically:** AI may explain the case's economics and argue against your
-reasoning; it may not write the brief. A hypothesis you did not generate cannot be honestly compared
-against results in Stage 3, and that comparison is the point. The other failure here is committing
-generic AI-written filler as your bio — it is obvious to any reader, and it is the first thing anyone
-sees.
+**For this stage specifically:** everything here is a means to the work rather than the work itself,
+so AI may build all of it and you verify. Three things to check in what it produces: no folder is
+named after a course or a term, every directory contains something, and the placeholder files are
+actually placeholders rather than invented biography. That last one is the failure that matters —
+committing generic AI-written filler as your bio is obvious to any reader, and it is the first thing
+anyone sees.
 
 ## 7. Verification
 
@@ -151,19 +135,16 @@ sees.
 - [ ] `AGENTS.md` written in your own words; `CLAUDE.md` is the one-line pointer
 - [ ] `RESUME.md` and `prompt-log.md` exist at the root — rough is acceptable
 - [ ] `.gitignore` filters Office and OS temp files
-- [ ] `docs/briefs/perfect-competition-brief.md` restates the problem in your voice
-- [ ] The hypothesis names a specific mix **and** the mechanism behind it
-- [ ] The brief was committed **before** any modeling work started
+- [ ] Every skeleton directory holds at least one file
 - [ ] `adamwstauffer` invited as a collaborator
 - [ ] At least two commits, each with a message that says what changed
 
-## 8. Rubric (3 pts)
+## 8. Rubric (2 pts)
 
 | Criterion | Pts | What distinguishes strong work |
 |---|---|---|
 | Repo live and public, professionally named | 1 | URL works without login; `firstname-lastname` naming; the bio in `README.md` is not placeholder text |
 | Skeleton, `.gitignore`, and commit hygiene | 1 | `docs/briefs/` in place and the root files present (`AGENTS.md`, `CLAUDE.md`, `RESUME.md`, `prompt-log.md`); junk files filtered; at least two descriptive commits |
-| Brief quality — genuine hypothesis | 1 | Problem restated accurately in your own voice; hypothesis names a specific mix with economic reasoning, written before any Solver work |
 
 ## 9. Common failure modes
 
@@ -171,15 +152,13 @@ sees.
 |---|---|
 | The repository is private, so nothing in it can be read | Settings → General → Change visibility → Public, then test the URL in a private window |
 | The repository is named after the course | Rename it now, while nothing links to it — a course-shaped repository stops meaning anything at graduation |
-| The hypothesis is hedged: "a balanced mix, because diversification" | Name quantities and a mechanism; a prediction that survives every outcome is not a prediction |
-| The brief is written after the workbook | There is no recovery — the Stage 3 comparison is gone. Write it first, even badly |
 | Empty directories disappear on push | Git tracks files, not folders; put a one-line `README.md` in each |
 | An hour spent polishing the bio on day one | It evolves all term. Get the repository live |
-| Commit messages read `update` | Say what changed: `Add brief: predicting tomato-heavy mix on price per bed` |
+| Commit messages read `update` | Say what changed: `Add portfolio skeleton and gitignore` |
+| `.gitignore` added after the first workbook commit | The junk is already in the history. Add it now anyway, and know that history is permanent |
 
 ## 10. References
 
-- [Portfolio repo standard](https://adamwstauffer.github.io/ai-lms/portfolio-repo.html) · [AI conventions](https://adamwstauffer.github.io/ai-lms/ai-conventions.html) · [Deliverable templates](https://adamwstauffer.github.io/ai-lms/deliverable-templates.html)
+- [Portfolio repo standard](https://adamwstauffer.github.io/ai-lms/portfolio-repo.html) · [AI conventions](https://adamwstauffer.github.io/ai-lms/ai-conventions.html)
 - [Git mechanics](https://adamwstauffer.github.io/ai-lms/onboarding.html#git-mechanics), including [`.gitignore`](https://adamwstauffer.github.io/ai-lms/onboarding.html#gitignore) and [how work is submitted, with the post-deadline revision policy](https://adamwstauffer.github.io/ai-lms/onboarding.html#submitting)
 - [`docs/guides/github-mba-guide.md`](../../../../../docs/guides/github-mba-guide.md) — the long-form Git reference, for troubleshooting
-- [Case README](README.md) — scenario, assumptions, constraints

--- a/courses/Micro-And-Macro-Economics/projects/in-progress/perfect-competition-marginal-costs/stage1-engagement-brief.md
+++ b/courses/Micro-And-Macro-Economics/projects/in-progress/perfect-competition-marginal-costs/stage1-engagement-brief.md
@@ -1,0 +1,135 @@
+---
+template: stage-brief
+project: perfect-competition-marginal-costs
+stage: 1
+title: "Engagement Brief"
+capability: marginal-analysis
+deliverables:
+  - path: docs/briefs/perfect-competition-brief.md
+    format: markdown
+    ai_boundary: human-first
+prerequisites: [0]
+points: 1
+estimated_time: "25-35 min"
+---
+
+# Case 1 · Stage 1 — Engagement Brief
+
+**Deliverable:** `docs/briefs/perfect-competition-brief.md`
+**Submission:** committed and pushed to your public repository; graded by inspection
+**Estimated time:** 25–35 minutes
+
+---
+
+## 1. Purpose
+
+One page stating the farm's problem in your own words and ending in a hypothesis you can be shown
+wrong about. It is not analysis. It is the condition that makes the analysis worth anything — the
+brief has to exist before the model does, because Stage 3 compares what you predicted against what
+the model found, and that comparison cannot be reconstructed afterwards.
+
+## 2. Prerequisites
+
+- Stage 0: the portfolio repository, with `docs/briefs/` in place.
+
+Read before starting:
+
+- [Deliverable templates](https://adamwstauffer.github.io/ai-lms/deliverable-templates.html) — the shape of a brief
+- The [case README](README.md) — scenario, assumptions table, constraints
+
+## 3. Deliverables
+
+| Artifact | Path | Format |
+|---|---|---|
+| The engagement brief | `docs/briefs/perfect-competition-brief.md` | markdown |
+
+## 4. Background
+
+A prediction written *before* the model runs is falsifiable. The same sentence written afterwards is
+a summary of the output, and it teaches you nothing, because you can no longer distinguish "I
+understood the economics" from "I read the answer cell."
+
+This is not a classroom convention. It is why a consultant writes an engagement brief before opening
+the data, and why "we always thought so" is the least trustworthy sentence in business. A wrong
+hypothesis, precisely reasoned, is worth as much as a correct one and considerably more than a lucky
+one.
+
+What makes a hypothesis genuine is that some outcome would refute it. *"I expect roughly 15 tomato
+beds, 20 carrot, 25 mesclun, because tomatoes earn about four times what carrots do per bed and I
+doubt the labor penalty closes that gap"* names quantities and a mechanism, and the model can
+contradict it. *"I expect a balanced mix because diversification reduces risk"* would survive any
+result, which is what disqualifies it.
+
+## 5. Procedure
+
+1. **Read the [case README](README.md)** — the scenario, the assumptions table, and the constraints.
+   These are the facts your brief restates. Do not invent numbers.
+   *Confirm:* you can state what the farm is deciding without looking back at the page.
+
+2. **Write the brief** at `docs/briefs/perfect-competition-brief.md`, using the structure on the
+   deliverable-templates page. **Before opening the workbook or Solver**, write half a page to a page
+   covering two things:
+   - **The problem in your own words.** What the farm is deciding, what is fixed, what is chosen,
+     what limits the choice. If you cannot state it without re-reading the case, you do not have it
+     yet, and that is useful information about where the next hour goes.
+   - **Your hypothesis.** *"I expect the optimal mix to be X because Y."* Real quantities — beds of
+     tomatoes, carrots, mesclun — and real reasoning: prices per bed, labor intensity, the
+     diminishing-returns percentages, the caps. Name the mechanism you think decides it.
+
+   *Confirm:* some outcome of the model would show your hypothesis wrong. If none would, it is not a
+   hypothesis yet.
+
+3. **Have it criticized, then answer the criticism yourself.** Ask a model to name your implicit
+   assumptions, your unsupported claims, and whether your hypothesis is falsifiable — and to
+   *not rewrite anything*. Then make the changes in your own words.
+   *Confirm:* the prompt is logged, and the words in the brief are yours.
+
+4. **Commit and push.** The message says what changed:
+   `Add perfect-competition brief with mix hypothesis`.
+   *Confirm:* the brief is committed **before any modeling begins**. The commit timestamp is what
+   makes it a hypothesis rather than a summary, and there is no way to add it later.
+
+## 6. AI use
+
+| Artifact | Draft order |
+|---|---|
+| `docs/briefs/perfect-competition-brief.md` | Human-first |
+
+**If the artifact is evidence of your judgment, you draft it first and AI reviews; if the artifact is
+a means to the work rather than the work itself, AI may draft it and you verify.** The two working
+loops are described in [AI conventions](https://adamwstauffer.github.io/ai-lms/ai-conventions.html).
+
+**For this stage specifically:** AI may explain the case's economics and argue against your
+reasoning; it may not write the brief. A hypothesis you did not generate cannot be honestly compared
+against results in Stage 3, and that comparison is the point. Criticism of a draft you have already
+written is in bounds and worth logging — the instruction that keeps it in bounds is *do not rewrite
+it*.
+
+## 7. Verification
+
+- [ ] `docs/briefs/perfect-competition-brief.md` restates the problem in your voice
+- [ ] The hypothesis names a specific mix **and** the mechanism behind it
+- [ ] Some model outcome would show the hypothesis wrong
+- [ ] The brief was committed **before** any modeling work started
+- [ ] Any AI critique session is logged in `prompt-log.md`
+
+## 8. Rubric (1 pt)
+
+| Criterion | Pts | What distinguishes strong work |
+|---|---|---|
+| Brief quality — genuine hypothesis | 1 | Problem restated accurately in your own voice; hypothesis names a specific mix with economic reasoning, written before any Solver work |
+
+## 9. Common failure modes
+
+| What goes wrong | The correction |
+|---|---|
+| The hypothesis is hedged: "a balanced mix, because diversification" | Name quantities and a mechanism; a prediction that survives every outcome is not a prediction |
+| The brief is written after the workbook | There is no recovery — the Stage 3 comparison is gone. Write it first, even badly |
+| The problem statement paraphrases the case README sentence by sentence | Restating is not copying. If you cannot say it differently, you do not have it yet |
+| The AI critique came back as a rewritten brief | You asked the wrong question. Ask it to name gaps and stop, then fix them yourself |
+| Commit messages read `update` | Say what changed: `Add brief: predicting tomato-heavy mix on price per bed` |
+
+## 10. References
+
+- [Deliverable templates](https://adamwstauffer.github.io/ai-lms/deliverable-templates.html) · [AI conventions](https://adamwstauffer.github.io/ai-lms/ai-conventions.html)
+- [Case README](README.md) — scenario, assumptions, constraints

--- a/docs/templates/stage-brief-template.md
+++ b/docs/templates/stage-brief-template.md
@@ -53,7 +53,7 @@ estimated_time: "{n}–{m} min"
 
 | Field | Why it exists |
 |---|---|
-| `stage` | Integer, numbered **per case from 1** — the containing folder already scopes the case, so the filename does not encode it twice (`2026-08-02-pr-release-process-and-stage-naming.md`). |
+| `stage` | Integer, numbered **per case from 1** — the containing folder already scopes the case, so the filename does not encode it twice (`2026-08-02-pr-release-process-and-stage-naming.md`). **Exception: a case that stands up the student's portfolio repository numbers that stage `0`**, because it produces the workspace rather than a step of the analysis, and only one case per course does it (2026-08-03). |
 | `deliverables` | The canonical **declaration** of the artifact paths. Prose in the body may reference a path but never introduce one. |
 | `ai_boundary` | Sits on each deliverable, not on the stage — a repo skeleton and a falsifiable hypothesis produced in the same stage carry different boundaries. The § 6 stage-level line is derived from these values; the AI tutor consumes them per artifact. |
 | `prerequisites` | Makes the self-contained rule checkable, and names what progression gating keys on. |


### PR DESCRIPTION
Content half of the Stage 0 pair — implements ruling **B1** of `ai-lms/docs/decisions/2026-08-03-case-flow-and-chrome-review.md`. **Merge before the ai-lms Stage 0 PR**, which mirrors these briefs.

## This is a regroup, not a repricing

The escalation asked how to divide the stage's three points. The answer is that they were never a pool to divide — `stage1-repo-and-brief.md` already priced **three criteria separately**, two about the repository and one about the brief, so the split falls along a seam that was already there.

| Stage | Criteria that move | Points |
|---|---|---|
| **Stage 0 — the repository** | repo live/public/named (1) · skeleton, `.gitignore`, collaborator, hygiene (1) | **2** |
| **Stage 1 — the brief** | brief quality (1) | **1** |

**Every criterion keeps its exact point value. No criterion text was rewritten. Case total stays 20** (2 + 1 + 8 + 9). Nothing in the locked set moves — which is why this could be settled at review rather than sent onward.

## Why a graded gate rather than a card on the case page

Standing up a workspace and forming a falsifiable hypothesis are different kinds of work with **different AI boundaries** — the repository is `ai-first-verified` throughout, the brief is `human-first` throughout. A gate between them is what makes the repository actually *finished* before the brief is written rather than half-built alongside it.

The commit-order rule stays on **Stage 1**, where the thing it orders lives: the brief must be committed before any modeling, and that timestamp cannot be reconstructed later.

## What each brief gained

- **Stage 0 § 6** — the three checks to run on an AI-built skeleton: no course-named folders, no empty directories, placeholders that are actually placeholders. That last is the failure that matters; a generic AI-written bio is the first thing anyone sees.
- **Stage 1 § 5** — the critique step (ask a model to name gaps and *not* rewrite), matching the callout on the Kumu page, plus a falsifiability `*Confirm:*` line, since a hypothesis that survives every outcome is this stage's most common failure.

## Template

The stage-numbering rule gains its exception: stages are numbered per case from 1, **except the one case per course that stands up the portfolio repository**, which numbers that stage 0 — it produces the workspace rather than a step of the analysis. **This is the precedent Corporate Finance and Finance & Securities inherit at their conversions**, which is why it's written into the template rather than left as a Case 1 anecdote.

Also updated: the case README's deliverables table and stage split (with the regroup recorded inline), the two offering READMEs' week-1 line and stage-count range, and the in-progress index. Cases 2 and 3 keep two stages.

**Drop-dead: built and verified by 2026-08-17, or this slips to Spring 2027** — it touches the gate engine and the two briefs a student hits in week 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ABgM3WZyWatdh7ykxWpU1