### PR TITLE
Fix path allowlist silently zeroing deliverables with special characters

### DIFF
--- a/courses/International-Finance-And-Securities/projects/fx-hedging/_tools/_repo.py
+++ b/courses/International-Finance-And-Securities/projects/fx-hedging/_tools/_repo.py
@@ -28,7 +28,15 @@ INSTRUCTOR_GITHUB_HANDLE = "adamwstauffer"
 _SAFE_OWNER_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$")
 _SAFE_REPO_RE = re.compile(r"^[A-Za-z0-9._-]{1,100}$")
 _SAFE_BRANCH_RE = re.compile(r"^[A-Za-z0-9._/-]{1,255}$")
-_SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9 ._/-]{1,300}$")
+# Students commit real deliverables under names GitHub allows but a tight
+# allowlist doesn't — unfilled template braces (`{Badua}-{scenario-slug}`),
+# colons from a flattened path (`docs:decisions:…`), parentheses, commas. A
+# rejected path made download_bytes return None *without any request*, so the
+# deliverable read as empty and the stage scored it a non-submission. Since the
+# path is passed to `gh` as a single argv element there is no shell to inject
+# into; the property that actually matters is no traversal and no control
+# characters, which is what this enforces.
+_SAFE_PATH_RE = re.compile(r"^(?!.*(?:^|/)\.\.(?:/|$))[^\x00-\x1f\\]{1,300}$")
 _SAFE_HANDLE_RE = re.compile(r"^[A-Za-z0-9-]{1,39}$")
 
 GITHUB_URL_RE = re.compile(


### PR DESCRIPTION
## Problem

`_SAFE_PATH_RE` in `_tools/_repo.py` only permitted `[A-Za-z0-9 ._/-]`. Any repo path containing another character made `download_bytes` return `None` **before issuing any request** — so the deliverable read as empty text and the stage scanner recorded it as a non-submission scoring **0**.

The failure is silent: no error, no flag, just `NO_MEMO` on a memo that exists.

## Impact

Three FIN-321 Stage 1 memos, all genuine submissions:

| Student | Path | Blocked by |
|---|---|---|
| Allan Jay Badua | `docs/decisions/2026-07-31{Badua}-{scenario-slug}-hedge-framing.md` | `{` `}` |
| Caoyu Chen | `docs/decisions/docs:decisions:2026-07-30-Chen-...md` | `:` |
| Achilles Del Rosario | `docs/decisions/2026-07-31-Del Rosario-{scenario-slug}-...md` | `{` `}` |

Students routinely leave the template braces in the filename, or flatten a path into colons — both produce names GitHub accepts and the allowlist refused. Badua's memo is 733 substantive words and scored 0.

## Fix

The path is passed to `gh` as a single argv element, so there is no shell to inject into. The properties that actually matter are **no traversal** and **no control characters** — enforce those instead of an alphabet allowlist.

```
^(?!.*(?:^|/)\.\.(?:/|$))[^\x00-\x1f\]{1,300}$
```

Verified: the three paths above now pass; `../../etc/passwd`, `docs/../../secret`, `..`, `a\x00b`, and `docs\win` are still rejected.

## Result

Stage 1 re-swept (generosity-only, so no score could fall): **Badua 0 → 88, Chen 0 → 94, Del Rosario 0 → 80**. Stage 1 now reports 19 submissions, up from 16. Stages 0 and 2–5 re-checked — no student changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)