### PR TITLE
Grade Stage 1 memos filed outside docs/decisions/

### DIFF
--- a/courses/International-Finance-And-Securities/projects/fx-hedging/_tools/grade_stage1.py
+++ b/courses/International-Finance-And-Securities/projects/fx-hedging/_tools/grade_stage1.py
@@ -54,6 +54,18 @@ MEMO_RE = re.compile(r"docs/decisions/[^/]*(?:hedge|framing|memo)[^/]*$", re.IGN
 # a short stub sitting at any of these paths is rejected later by the word-count
 # guard, not by name.
 FALLBACK_RE = re.compile(r"^docs/decisions(?:/[^/]+|\.md)?$", re.IGNORECASE)
+# Last resort: a memo-named markdown file *anywhere* in the repo — a student who
+# filed the memo under `Docs/`, `memos/`, or the repo root has submitted it, and
+# the two patterns above would score that a zero on filing alone, which is the
+# opposite of this section's stated intent. Deliberately last so a canonical memo
+# always wins; `pick_text` drops template stubs and prefers the longest file, and
+# the word-count guard below still rejects a short stub that happens to match.
+ANYWHERE_RE = re.compile(r"(?:^|/)[^/]*(?:hedge|framing|memo)[^/]*\.md$", re.IGNORECASE)
+# ...but never an unfilled template. `strip_templates` only catches the
+# placeholder tokens (`lastname`, `yyyy-mm-dd`); a student who copied
+# `template-decision-memo.md` into their repo verbatim has not submitted a memo,
+# and repo-wide matching would otherwise grade them on the template's own prose.
+TEMPLATE_MEMO_RE = re.compile(r"(?:^|/)_?templates?/|(?:^|/)template[-_]", re.IGNORECASE)
 MEMO_MIN_WORDS = 40  # below this a "memo" is a placeholder/stub, not a submission
 
 # --- text-detection patterns ----------------------------------------------
@@ -237,6 +249,9 @@ def grade(sub: Submission, prior_weak: bool = False) -> StudentReport:
     memo_paths = [p for p in st.tree if MEMO_RE.search(p)]
     if not memo_paths:
         memo_paths = [p for p in st.tree if FALLBACK_RE.search(p)]
+    if not memo_paths:
+        memo_paths = [p for p in st.tree
+                      if ANYWHERE_RE.search(p) and not TEMPLATE_MEMO_RE.search(p)]
 
     if not memo_paths:
         flags.append("NO_MEMO")


### PR DESCRIPTION
## What

`grade_stage1.py` only discovered memos anchored to `docs/decisions/`, so a substantive memo committed to `Docs/`, `memos/`, or the repo root scored **0** on filing alone.

That contradicts the module's own stated design — the comment above the patterns says discovery is *"deliberately lenient on filing (extension / exact location) so a real, substantive memo still gets graded on its content — the canonical path is nudged via the Professionalism `correct_location` check, not a zero."* The `MEMO_LOCATION` flag and its student-facing suggestion ("found and graded on its content... small professionalism deduction only, no content penalty") already existed; only the discovery tier was missing.

## Change

- New last-resort tier: a memo-named `.md` **anywhere** in the tree, tried only after the two existing anchored patterns.
- Excludes anything under a `templates/` dir or named `template-*`. `strip_templates` only catches the `lastname` / `yyyy-mm-dd` placeholder tokens, so a student who copied `template-decision-memo.md` in verbatim would otherwise have been graded on the template's own prose.
- The existing 40-word guard still rejects stubs; `pick_text` still prefers the longest non-template candidate.

## Verification

Re-ran discovery against all 20 graded Stage 1 repos: **every one matches at tier 1**, so the new tier is unreachable for them and no existing score moves. It fires only where the old code returned `NO_MEMO`.

Found via Justin Toyama's makeup grade — memo at `Docs/2026-08-04-fx-hedging-memo.md`, previously 0, now graded on content (raw 69.2 → 80 floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gWWakUtDtE1YrgLpsKgVg