### PR TITLE
fx-hedging grading tools: robust paths, heading-aware findings, sweep floor fix

### DIFF
--- a/courses/International-Finance-And-Securities/projects/fx-hedging/_tools/_repo.py
+++ b/courses/International-Finance-And-Securities/projects/fx-hedging/_tools/_repo.py
@@ -21,6 +21,7 @@ import subprocess
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
+from urllib.parse import quote
 
 INSTRUCTOR_GITHUB_HANDLE = "adamwstauffer"
 
@@ -28,15 +29,16 @@ INSTRUCTOR_GITHUB_HANDLE = "adamwstauffer"
 _SAFE_OWNER_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})$")
 _SAFE_REPO_RE = re.compile(r"^[A-Za-z0-9._-]{1,100}$")
 _SAFE_BRANCH_RE = re.compile(r"^[A-Za-z0-9._/-]{1,255}$")
-# Students commit real deliverables under names GitHub allows but a tight
-# allowlist doesn't — unfilled template braces (`{Badua}-{scenario-slug}`),
-# colons from a flattened path (`docs:decisions:…`), parentheses, commas. A
-# rejected path made download_bytes return None *without any request*, so the
-# deliverable read as empty and the stage scored it a non-submission. Since the
-# path is passed to `gh` as a single argv element there is no shell to inject
-# into; the property that actually matters is no traversal and no control
-# characters, which is what this enforces.
-_SAFE_PATH_RE = re.compile(r"^(?!.*(?:^|/)\.\.(?:/|$))[^\x00-\x1f\\]{1,300}$")
+# Repo paths are deliberately permissive: GitHub accepts almost any character in
+# a filename, and students routinely commit memos with `:`, `{}`, or parentheses
+# in the name (a mangled `docs:decisions:…md`, an unreplaced `{scenario-slug}`).
+# The old `[A-Za-z0-9 ._/-]` allow-list rejected those, so `download_text`
+# returned None and a real, substantive submission scored a silent 0. `gh` is
+# invoked with an argv list (never a shell), so the only things that actually
+# need excluding are control characters, backslashes, and a leading `-` (which
+# `gh` would parse as a flag). The path is percent-encoded in `_contents_ref`
+# before it reaches the API, which handles `#`, `?`, and `%` safely.
+_SAFE_PATH_RE = re.compile(r"^(?!-)[^\x00-\x1f\\]{1,300}$")
 _SAFE_HANDLE_RE = re.compile(r"^[A-Za-z0-9-]{1,39}$")
 
 GITHUB_URL_RE = re.compile(
@@ -210,13 +212,23 @@ def _check_collaborator(owner: str, repo: str, handle: str) -> bool:
     return data.get("permission") in ("write", "admin", "maintain")
 
 
+def _contents_ref(owner: str, repo: str, path: str) -> str:
+    """Build the `contents` API endpoint with the path percent-encoded.
+
+    Path separators stay literal; everything else (spaces, `#`, `?`, `%`, `:`)
+    is escaped so an unusual-but-legal filename resolves instead of silently
+    404-ing partway through the path.
+    """
+    return f"repos/{owner}/{repo}/contents/{quote(path, safe='/')}"
+
+
 def download_bytes(owner: str, repo: str, path: str, branch: str) -> bytes | None:
     """Fetch a file blob from the repo; None on failure. Handles base64."""
     if not (_SAFE_OWNER_RE.match(owner) and _SAFE_REPO_RE.match(repo)
             and _SAFE_PATH_RE.match(path) and _SAFE_BRANCH_RE.match(branch)):
         return None
     data = _gh_json(
-        "api", f"repos/{owner}/{repo}/contents/{path}", "-X", "GET", "-f", f"ref={branch}",
+        "api", _contents_ref(owner, repo, path), "-X", "GET", "-f", f"ref={branch}",
     )
     if not isinstance(data, dict) or data.get("encoding") != "base64":
         return None

--- a/courses/International-Finance-And-Securities/projects/fx-hedging/_tools/_xlsx.py
+++ b/courses/International-Finance-And-Securities/projects/fx-hedging/_tools/_xlsx.py
@@ -39,6 +39,14 @@ HEDGE_KEYWORDS = {
 }
 
 FINDING_LINE_RE = re.compile(r"^\s*(?:\d+\.|[-*])\s+\S")
+# A finding written as its own heading (`## Finding 1 — Broken cross-reference`,
+# `### Issue 2: ...`) is at least as substantive as a bullet, but matches none of
+# the list patterns above — counting only bullets scored a well-structured,
+# three-finding note as zero. Headings are counted alongside list items.
+FINDING_HEADING_RE = re.compile(
+    r"^\s{0,3}#{1,6}\s*(?:finding|issue|error|bug|defect|observation|problem)\b",
+    re.IGNORECASE,
+)
 FINDING_VERB_RE = re.compile(
     r"\b(found|fixed|checked|corrected|confirmed|verified|caught|missing|hardcoded|wrong)\b",
     re.IGNORECASE,
@@ -147,6 +155,11 @@ def count_audit_findings(text: str) -> int:
     """Approximate substantive-finding count in a build-audit / validation note."""
     if not text:
         return 0
-    list_items = sum(1 for ln in text.splitlines() if FINDING_LINE_RE.match(ln))
+    lines = text.splitlines()
+    headings = sum(1 for ln in lines if FINDING_HEADING_RE.match(ln))
+    list_items = sum(1 for ln in lines if FINDING_LINE_RE.match(ln))
+    # A heading-structured note ("## Finding 1") and a bullet-structured one are
+    # equally valid; take whichever structure the student actually used.
+    items = max(headings, list_items)
     verbs = len(FINDING_VERB_RE.findall(text))
-    return max(min(list_items, verbs), list_items if verbs else 0)
+    return max(min(items, verbs), items if verbs else 0)

--- a/courses/International-Finance-And-Securities/projects/fx-hedging/_tools/sweep_stage.py
+++ b/courses/International-Finance-And-Securities/projects/fx-hedging/_tools/sweep_stage.py
@@ -108,7 +108,8 @@ def main(argv: list[str] | None = None) -> int:
     for r in reports:
         d = fb_root / _repo.lastname_slug(r.name)
         d.mkdir(parents=True, exist_ok=True)
-        (d / "feedback-file.md").write_text(build_pr_feedback(args.stage, r, today), encoding="utf-8")
+        (d / "feedback-file.md").write_text(
+            build_pr_feedback(args.stage, r, today, floor), encoding="utf-8")
     print(f"Refreshed {len(reports)} PR-feedback files.")
     return 0
 


### PR DESCRIPTION
Commits the local `_tools` edits that were sitting uncommitted in the working tree (preserved through the 2026-08-06 hub-refresh sync; backup remains in `git stash`).

- **`_repo.py`** — percent-encodes the contents-API path (`_contents_ref`) so legal-but-unusual student filenames (`#`, `?`, `%`, `:`, spaces) resolve instead of silently 404-ing into a non-submission; the path allowlist now matches the actual threat model of an argv-list `gh` invocation (control chars, backslash, leading dash). One thing to eyeball: this version drops the explicit `..` traversal lookahead the on-main version carried — the read-only GET makes it low-stakes, but it is a loosening.
- **`_xlsx.py`** — `count_audit_findings` now counts heading-structured findings (`## Finding 1 — …`) alongside bullets; a well-structured three-finding note previously scored zero.
- **`sweep_stage.py`** — passes `floor` through to `build_pr_feedback`, whose signature requires `floor_pct`; without it the PR-feedback refresh raised a TypeError.

All three compile; `floor` is defined in the caller's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L6jN8PcjDEJYJ1tHckH2sx