### PR TITLE
Add the Stage 0 portfolio-repo sample to Micro/Macro

### DIFF
--- a/courses/Micro-And-Macro-Economics/README.md
+++ b/courses/Micro-And-Macro-Economics/README.md
@@ -11,6 +11,7 @@ Microeconomic and macroeconomic theory applied to real-world business and policy
 
 ## Shared Curriculum
 
+- [`sample/`](sample/) — reference skeleton of the [portfolio repo standard](https://adamwstauffer.github.io/ai-lms/portfolio-repo.html), the structure [Stage 0](https://adamwstauffer.github.io/ai-lms/github-stage0.html) asks students to stand up under their own account
 - [`projects/individual-research/`](projects/individual-research/) — individual research paper with peer-review rubric
 - [`projects/team-research/`](projects/team-research/) — team case-study presentations
 - [`projects/`](projects/) — the three graded case projects with stage briefs (Perfect Competition → Imperfect Competition → Economic Rent; 10% each, Fall 2026); Case 1 released, Cases 2-3 pending instructor sign-off
@@ -24,11 +25,17 @@ Micro-And-Macro-Economics/
 ├── BUS-620-DLEMBA/                                 offering: syllabus (in setup)
 │   └── README.md
 ├── projects/
+│   ├── perfect-competition-marginal-costs/          Case 1 — stage briefs + workbooks
+│   ├── imperfect-competition-marginal-revenue/      Case 2 — stage briefs + workbooks
+│   ├── accounting-profit-economic-profit-economic-rent/  Case 3 — stage briefs + workbooks
 │   ├── individual-research/                         individual research paper + peer-review rubric
-│   ├── in-progress/                                  case studies in development
-│   │   ├── accounting-profit-economic-profit-economic-rent/
-│   │   ├── imperfect-competition-marginal-revenue/
-│   │   └── perfect-competition-marginal-costs/
-│   └── team-research/                                team case-study presentations
+│   └── team-research/                               team case-study presentations
+├── sample/                                          portfolio-repo skeleton students build in Stage 0
+│   ├── README.md  RESUME.md  AGENTS.md  CLAUDE.md  prompt-log.md  .gitignore
+│   ├── .claude/skills/                              personal sandbox (ungraded)
+│   ├── capabilities/marginal-analysis/              README.md + spec.md + the model file
+│   ├── docs/{briefs,decisions}/                     before the work / after the work
+│   ├── data/                                        sourced inputs, with provenance
+│   └── analysis/figures/                            the findings + their charts
 └── README.md                                        you are here
 ```

--- a/courses/Micro-And-Macro-Economics/sample/.claude/skills/README.md
+++ b/courses/Micro-And-Macro-Economics/sample/.claude/skills/README.md
@@ -1,0 +1,10 @@
+# Personal skill sandbox
+
+Yours to experiment with, and **ungraded** — nothing in any course grades what you put here.
+
+`capabilities/` names what you can do in your own terms, for human readers; `.claude/skills/`
+is a tool-specific directory some AI tools load automatically. The two are deliberately
+compatible: a capability you build — the spec, the method notes, the model — can be copied here
+almost unchanged to become a personal AI skill that follows you to every project.
+
+Build the capability first; the skill falls out of it.

--- a/courses/Micro-And-Macro-Economics/sample/.gitignore
+++ b/courses/Micro-And-Macro-Economics/sample/.gitignore
@@ -1,0 +1,21 @@
+# Office temp and lock files
+~$*
+*.tmp
+*.xlk
+*.bak
+
+# OS cruft
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Credentials and secrets — never commit these, not even once.
+# History is permanent: a key committed and then deleted is still in the history.
+.env
+*.key
+*.pem
+credentials.json
+
+# Local editor state
+.vscode/
+.idea/

--- a/courses/Micro-And-Macro-Economics/sample/AGENTS.md
+++ b/courses/Micro-And-Macro-Economics/sample/AGENTS.md
@@ -1,0 +1,68 @@
+# AI conventions
+
+<!-- SAMPLE — this is the baseline from
+     https://adamwstauffer.github.io/ai-lms/ai-conventions.html, lightly adapted.
+     Copy it into your own repository, then edit until it describes you rather than a
+     generic student. A file you did not write will not match how you actually work,
+     and you will stop trusting it within a week. -->
+
+## About this repository
+
+One-line description of what this repo is and who owns it.
+Canonical file: `AGENTS.md`. `CLAUDE.md` points here.
+
+## Where things are
+
+- `capabilities/<capability>/`  a capability, with its spec and model
+- `docs/briefs/`          written BEFORE work: scope + hypothesis
+- `docs/decisions/`       written AFTER work: recommendations
+- `analysis/`             findings and figures
+- `data/`                 sourced inputs, with provenance
+
+## Naming
+
+- The directory matters most. A file in the wrong folder may not be found at all. If you are
+  not certain which folder a file belongs in, ask me before you write it — do not choose for me.
+- Graded files use the exact filename the stage brief gives — lowercase, hyphens, no spaces.
+  Some courses date-stamp (`YYYY-MM-DD-lastname-slug.md`); the stage page says so when they do.
+- Slugs name the engagement, never the week, the course, or the assignment number.
+- Never invent a path or a filename. I will give you the exact one.
+
+## How I work
+
+- Explain concepts fully and walk the worked example. Do not hand me conclusions.
+- Critique my reasoning directly. I would rather be corrected than agreed with.
+- When you are uncertain, say so and say what would resolve it.
+
+## What you may and may not draft
+
+- You MAY explain, critique, debug, quiz me, and draft mechanical files.
+- You MAY NOT write my briefs, analyses, memos, or reflections.
+- Every statistic or figure you give me is a draft until I verify it against a source.
+
+## Documentation
+
+When work changes, update the document that describes it in the same commit.
+A capability's README names the engagements that exercised it — keep that current.
+
+## Scope
+
+Do the work I asked for. If you notice something worth doing that I did not ask for, tell me
+instead of doing it.
+
+## Commits
+
+Descriptive messages: what changed and why. Never "update" or "stuff".
+
+## Never include
+
+No credentials, no API keys, no personal data about anyone, no licensed or copyrighted material.
+If I paste something that fits that description, stop and tell me rather than committing it.
+
+## Mistakes to avoid (append to this list)
+
+Record errors here as they happen, so the same one does not repeat. This is the section that
+compounds — a correction written down once stops recurring; a correction delivered in chat is
+gone tomorrow.
+
+- (empty — add the first one when it happens)

--- a/courses/Micro-And-Macro-Economics/sample/CLAUDE.md
+++ b/courses/Micro-And-Macro-Economics/sample/CLAUDE.md
@@ -1,0 +1,1 @@
+All agent instructions for this repository live in [AGENTS.md](AGENTS.md) — read that file.

--- a/courses/Micro-And-Macro-Economics/sample/README.md
+++ b/courses/Micro-And-Macro-Economics/sample/README.md
@@ -1,0 +1,79 @@
+# firstname-lastname
+
+> **This is a sample, not a student repository.** It is a working copy of the
+> [portfolio repo standard](https://adamwstauffer.github.io/ai-lms/portfolio-repo.html) — the
+> skeleton [Stage 0, part 2](https://adamwstauffer.github.io/ai-lms/github-stage0.html) asks you to
+> stand up under your **own** GitHub account, named for you. Browse it to see what the structure
+> looks like once it exists. Do not fork it, and do not copy the placeholder prose: the bio is the
+> first thing any reader sees, and generic filler is obvious.
+>
+> Everything below this line is what *your* `README.md` would hold.
+
+---
+
+<!-- PLACEHOLDER — replace with three to six sentences on who you are, what you have done,
+     and what you are working toward. Write it in your own voice; an LLM may draft it, but
+     ship nothing you would not want read aloud. -->
+
+*Three to six sentences on who you are and what you are working toward go here.*
+
+## Engagements
+
+The index is the by-subject view of this repository — it lives here, never in the folder paths.
+Each row links a piece of work to its brief, its analysis, and its memo.
+
+| Engagement | Capability | Brief | Analysis | Memo |
+|---|---|---|---|---|
+| *(engagement name)* | [`marginal-analysis`](capabilities/marginal-analysis/) | `docs/briefs/` | `analysis/` | `docs/decisions/` |
+
+## Structure
+
+```
+firstname-lastname/
+├── README.md            who you are + the index of engagements
+├── RESUME.md            Markdown resume
+├── AGENTS.md            your AI conventions — the canonical file
+├── CLAUDE.md            one line pointing to AGENTS.md
+├── prompt-log.md        the running record of AI sessions that mattered
+├── .gitignore           what must never enter the history
+├── .claude/skills/      personal sandbox — yours to experiment with, ungraded
+├── capabilities/        one folder per capability
+│   └── marginal-analysis/
+│       ├── README.md    what the capability is + which engagements exercised it
+│       ├── spec.md      the method: model design, named ranges, formula logic
+│       └── model.xlsx   starts as a template, becomes your model
+├── docs/
+│   ├── briefs/          BEFORE the work: scope + hypothesis
+│   └── decisions/       AFTER the work: the recommendation, to an audience
+├── data/                sourced inputs, with provenance
+└── analysis/            the findings
+    └── figures/         charts the findings refer to
+```
+
+Three distinctions carry the whole structure:
+
+- **Briefs ask; memos answer.** A brief is written *before* the work and commits you to a
+  hypothesis you can be wrong about. A brief written afterwards is a summary of the answer.
+- **Capabilities are what you can do; engagements are evidence.** `capabilities/` holds the
+  method; `docs/`, `data/`, and `analysis/` hold the proof you exercised it.
+- **The spec and the model live together.** A method and the workbook implementing it are one
+  object — splitting them into a `specs/` folder creates two places to look and no payoff.
+
+## Two mechanical facts
+
+**Git tracks files, not folders.** An empty directory does not survive a push. Every directory
+here holds a one-line `README.md` for exactly that reason — which is more useful to a reader
+than an empty folder anyway.
+
+**History is permanent.** A file committed once stays in the history after it is deleted. That
+is why `.gitignore` goes in *before* the first workbook, and why credentials never get committed
+even briefly.
+
+## Naming
+
+- Repository named for the person — `firstname-lastname`, or `firstname-lastname-portfolio` if
+  taken. Never for a course, a semester, or a week.
+- Files named for the engagement: `perfect-competition-brief.md` still makes sense to a stranger
+  in three years; `week1.md` does not.
+- Slugs lowercase and hyphen-separated, three to six words. No spaces, no underscores.
+- Dated documents lead with the ISO date — `YYYY-MM-DD-slug.md` — so a listing sorts itself.

--- a/courses/Micro-And-Macro-Economics/sample/RESUME.md
+++ b/courses/Micro-And-Macro-Economics/sample/RESUME.md
@@ -1,0 +1,31 @@
+# firstname lastname
+
+<!-- PLACEHOLDER — this is a sample file in the course repository, not a real resume.
+     In your own repository, replace everything below with your actual history.
+     Rough is acceptable on the first day; it evolves all term. Never let an LLM
+     invent an employer, a title, a date, or a result. -->
+
+*(city · email · LinkedIn · github.com/{you})*
+
+## Summary
+
+*One or two sentences: what you do, and what you are moving toward.*
+
+## Experience
+
+**Title — Organization** · *Month YYYY – Month YYYY*
+- *What you were responsible for, and what changed because of it. Numbers where you have them.*
+
+## Education
+
+**Degree — Institution** · *YYYY*
+
+## Skills
+
+*Tools, methods, and languages you would be comfortable being asked about in an interview.*
+
+## Portfolio
+
+Each capability in [`capabilities/`](capabilities/) links to the engagements that exercised it —
+that claim-to-proof line is the reason a Markdown resume lives in a repository rather than a PDF
+in a folder.

--- a/courses/Micro-And-Macro-Economics/sample/analysis/README.md
+++ b/courses/Micro-And-Macro-Economics/sample/analysis/README.md
@@ -1,0 +1,8 @@
+# Analysis
+
+The findings — what the model shows, with the figures the reader needs to follow the argument.
+This is the evidence between the brief that asked the question and the memo that answers it.
+
+**Naming:** `<engagement>-analysis.md` — for example, `perfect-competition-analysis.md`.
+
+- [`figures/`](figures/) — the charts the findings refer to.

--- a/courses/Micro-And-Macro-Economics/sample/analysis/figures/README.md
+++ b/courses/Micro-And-Macro-Economics/sample/analysis/figures/README.md
@@ -1,0 +1,7 @@
+# Figures
+
+Charts and exhibits the analysis refers to, exported from the model rather than pasted as
+screenshots where the format allows it.
+
+Name each figure for what it shows and the engagement it belongs to — `perfect-competition-mc-mr.png`
+tells a reader something; `chart1.png` does not.

--- a/courses/Micro-And-Macro-Economics/sample/capabilities/README.md
+++ b/courses/Micro-And-Macro-Economics/sample/capabilities/README.md
@@ -1,0 +1,18 @@
+# Capabilities
+
+One folder per capability — `marginal-analysis`, `pricing-power`, `fx-hedging`, whatever you turn
+out to be able to do. Never a folder named for a course, a semester, or a week.
+
+A capability folder holds three things:
+
+| File | What it is |
+|---|---|
+| `README.md` | what the capability is, and which engagements exercised it |
+| `spec.md` | the method: model design, named ranges, formula logic |
+| the model file | starts as a template, becomes your model |
+
+The spec and the model live together because a method and the workbook implementing it are one
+object. Splitting them into a `specs/` folder creates two places to look and no payoff.
+
+Capabilities are what you can do; the engagements in `docs/`, `data/`, and `analysis/` are the
+evidence that you did. Each README's link from claim to proof is the line a reader follows.

--- a/courses/Micro-And-Macro-Economics/sample/capabilities/marginal-analysis/README.md
+++ b/courses/Micro-And-Macro-Economics/sample/capabilities/marginal-analysis/README.md
@@ -1,0 +1,22 @@
+# Marginal analysis
+
+<!-- SAMPLE capability folder. Replace with your own once you have exercised the capability. -->
+
+**What it is.** Deciding how much to produce by comparing the cost of the next unit against the
+revenue it brings in — the point where marginal cost meets marginal revenue, and why that point,
+not average cost, sets the profit-maximizing quantity.
+
+**What I can do with it.** *(One or two sentences a reader could hold you to: the kind of question
+you can answer and the kind of model you can build to answer it.)*
+
+## Engagements that exercised it
+
+| Engagement | Brief | Analysis | Memo |
+|---|---|---|---|
+| *(engagement name)* | [`docs/briefs/`](../../docs/briefs/) | [`analysis/`](../../analysis/) | [`docs/decisions/`](../../docs/decisions/) |
+
+## Files here
+
+- [`spec.md`](spec.md) — the method, precise enough for someone else to rebuild the model from
+- `model.xlsx` — the workbook itself. *(Not committed in this sample; in a real repository the
+  file lives here, beside the spec that describes it.)*

--- a/courses/Micro-And-Macro-Economics/sample/capabilities/marginal-analysis/spec.md
+++ b/courses/Micro-And-Macro-Economics/sample/capabilities/marginal-analysis/spec.md
@@ -1,0 +1,49 @@
+---
+type: spec
+capability: marginal-analysis
+artifact: model.xlsx
+updated: YYYY-MM-DD
+---
+
+# Spec — marginal-analysis model
+
+<!-- SAMPLE. The spec defines the artifact precisely enough that somebody else could rebuild it
+     without asking you a question. Headings below are the shape; the content is yours. -->
+
+## Purpose
+
+*What decision the model supports, and for whom.*
+
+## Inputs
+
+| Input | Cell / named range | Units | Source |
+|---|---|---|---|
+| *(input)* | `Inputs!B4` | *(units)* | [`data/`](../../data/) |
+
+Every input is a literal typed once, in one place. Nothing downstream is hardcoded.
+
+## Calculations
+
+| Output | Formula logic | Depends on |
+|---|---|---|
+| Total cost | *(stated in words, then the formula)* | inputs above |
+| Marginal cost | change in total cost ÷ change in quantity | total cost column |
+| Profit-maximizing quantity | the last unit where MR ≥ MC | MC, MR columns |
+
+**Every calculated cell is a formula.** Only raw source data is a literal — a typed-in number
+where a formula belongs is the single most common defect in a submitted workbook, and it breaks
+the moment an input changes.
+
+## Named ranges
+
+| Name | Refers to | Why it is named |
+|---|---|---|
+
+## Assumptions and limits
+
+*What the model takes as given, and the conditions under which its answer stops holding.*
+
+## How to verify it
+
+*The checks that show the model is right — a total that must tie, a value you can compute by
+hand, a sensitivity that must move in a known direction.*

--- a/courses/Micro-And-Macro-Economics/sample/data/README.md
+++ b/courses/Micro-And-Macro-Economics/sample/data/README.md
@@ -1,0 +1,12 @@
+# Data
+
+Sourced inputs, **with provenance**. For each file, record where it came from, when it was
+pulled, and any transformation you applied before it landed here — a number nobody can trace is a
+number nobody can defend.
+
+| File | Source | Retrieved | Notes |
+|---|---|---|---|
+| *(filename)* | *(publisher, URL, or the workbook it was given in)* | *(YYYY-MM-DD)* | *(cleaning or filtering applied)* |
+
+Nothing licensed, nothing confidential, and no personal data about anyone else. A public
+repository is publication, and history is permanent.

--- a/courses/Micro-And-Macro-Economics/sample/docs/README.md
+++ b/courses/Micro-And-Macro-Economics/sample/docs/README.md
@@ -1,0 +1,11 @@
+# Docs
+
+Two folders, and the distinction between them is load-bearing:
+
+- [`briefs/`](briefs/) — written **before** the work. The scope, and a hypothesis you can be
+  wrong about.
+- [`decisions/`](decisions/) — written **after** the work. The recommendation, addressed to an
+  audience.
+
+**Briefs ask; memos answer.** A brief written after the analysis is a summary of the answer,
+which is worth nothing to you and obvious to anyone reading in order.

--- a/courses/Micro-And-Macro-Economics/sample/docs/briefs/README.md
+++ b/courses/Micro-And-Macro-Economics/sample/docs/briefs/README.md
@@ -1,0 +1,11 @@
+# Briefs
+
+Written **before** any modeling. A brief states the problem in your own words and commits you to
+a prediction you can be shown wrong about.
+
+**Naming:** `<engagement>-brief.md` — for example, `perfect-competition-brief.md`. Name it for
+the engagement, never for the week or the assignment number.
+
+Every brief opens with YAML frontmatter (`type`, `engagement`, `author`, `date`) so a reader —
+human or model — can tell what the document is without opening it. The template is on
+[Deliverable templates](https://adamwstauffer.github.io/ai-lms/deliverable-templates.html).

--- a/courses/Micro-And-Macro-Economics/sample/docs/decisions/README.md
+++ b/courses/Micro-And-Macro-Economics/sample/docs/decisions/README.md
@@ -1,0 +1,11 @@
+# Decisions
+
+Written **after** the work. The memo is what the reader gets at the end: the recommendation, what
+it rests on, what would change it, and what it costs to be wrong.
+
+**Naming:** `<engagement>-memo.md` — for example, `perfect-competition-memo.md`. Documents tied
+to a date lead with the ISO date instead: `2026-09-04-vendor-switch.md`, so the folder listing
+sorts chronologically on its own.
+
+Template and frontmatter keys:
+[Deliverable templates](https://adamwstauffer.github.io/ai-lms/deliverable-templates.html).

--- a/courses/Micro-And-Macro-Economics/sample/prompt-log.md
+++ b/courses/Micro-And-Macro-Economics/sample/prompt-log.md
@@ -1,0 +1,27 @@
+---
+type: prompt-log
+owner: firstname-lastname
+started: YYYY-MM-DD
+---
+
+# Prompt log
+
+One file at the repository root, appended to as you go — not reconstructed the night before a
+deadline, which produces a document that is fiction and reads like it. Log the sessions that
+changed what you did.
+
+<!-- The two rows below are illustrations of the format, not entries. Delete them and log
+     your own sessions. -->
+
+| Date | Tool | What I asked | What I got | What I did with it |
+|---|---|---|---|---|
+| *(example)* | Claude (web) | Why is my MC column falling between beds 5 and 7? | Pointed at the wage switch when permanent hours run out | Verified in the sheet; kept it and explained the dip in the analysis |
+| *(example)* | Claude Code | Draft the `.gitignore` for an Excel-heavy repo | Standard Office and OS patterns | Read it, added `~$*.xlsm`, committed |
+
+## Errors caught
+
+The part that is worth something later. A log claiming a model was flawless reads as a log kept
+by somebody who was not checking. When you catch one, record it here *and* in the mistakes
+section of [`AGENTS.md`](AGENTS.md) so it stops recurring.
+
+- *(empty — add the first one when it happens)*


### PR DESCRIPTION
Students building their portfolio repository in Stage 0, part 2 have the standard described to them on the course site but nothing to look at. This adds a browsable reference skeleton at courses/Micro-And-Macro-Economics/sample/, matching github-stage0.html and portfolio-repo.html exactly: the six root files (README, RESUME, AGENTS, CLAUDE pointer, prompt-log, .gitignore), the .claude/skills sandbox, capabilities/marginal-analysis/ with its spec, the docs/{briefs,decisions} split, data/, and analysis/figures/.

Every directory carries a stub README, both because git does not track empty folders and because that is the convention the stage teaches. The capability is marginal-analysis, matching the frontmatter of the Case 1 stage briefs. The model workbook is named but not committed, so nothing here reads as a real deliverable, and the bio, resume, and prompt-log rows are explicitly marked as placeholders.

Also refreshes the course README directory tree, which still showed the three cases nested under projects/in-progress/ after b0767bc promoted them.


Claude-Session: https://claude.ai/code/session_0165GKo7XQgBjUgJ38QtjBPW